### PR TITLE
Fix dragging in macOS impl and use new core_graphics crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ winapi = "0.2.8"
 user32-sys = "0.2.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-graphics = "0.8.0"
+core-graphics = "0.12.4"
 libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ user32-sys = "0.2.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.12.4"
+objc = "0.2.2"
 libc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,9 @@
 #[cfg(target_os = "macos")]
 extern crate libc;
 
+#[cfg(target_os = "macos")]
+#[macro_use] extern crate objc;
+
 // TODO(dustin) use interior mutability not &mut self
 
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
This PR does two things, in two commits:

- Updates the macOS implementation to the new `core_graphics` crate, this allows more use of the crate and less custom bindings. This leads to cleaner shorter code, and I also cleaned up the use of event sources so that it all uses one event source. Unfortunately the APIs take a `CGEventSource` rather than a `&CGEventSourceRef` like they should, so I have to clone it but that's just one more retain as opposed to allocating a new one every time.
- Use the `objc` crate to use `[NSEvent pressedMouseButtons]` to check which buttons are pressed and use that to determine if mouse movements should be move or drag events. Without this change all dragging such as selecting text doesn't work in most browsers, and many other apps. I'm using `enigo` with an app that emulates a mouse movement, but I use a separate mechanism to do clicking so it needs to read click state from the OS.