### PR TITLE
Add derive( Copy, Clone, PartialEq, Eq ) to the Key enum to facilitate usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ pub trait MouseControllable {
 
 /// Keys to be used TODO(dustin): make real documentation
 #[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Key {
     /// alt key on Linux and Windows (option key on macOS)
     Alt,


### PR DESCRIPTION
Especially since the methods of enigo that take variants of this enum take ownership.

See issue #53.