### PR TITLE
Warn Linux users that they may have to install libxdo-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ for more look at examples
 Runtime dependencies
 --------------------
 
-Linux users may have to install libxdo-dev:
+Linux users may have to install libxdo-dev. For example, on Ubuntu:
 
 ```Bash
-apt-get install libxdo-dev
+apt install libxdo-dev
 ```

--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@ enigo.key_sequence_parse("{+CTRL}a{-CTRL}{+SHIFT}Hello World{-SHIFT}");
 ```
 
 for more look at examples
+
+Runtime dependencies
+--------------------
+
+Linux users may have to install libxdo-dev:
+
+```Bash
+apt-get install libxdo-dev
+```


### PR DESCRIPTION
Hi,

I could not run the examples as-is because of the missing libxdo-dev on my Linux environment. I guess others will have the same issue so I thought I should write a PR. Feel free to edit, comment or reject.