### PR TITLE
Fix meta key on linux

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -201,7 +201,7 @@ fn keysequence<'a>(key: Key) -> Cow<'a, str> {
         Key::Tab => "Tab",
         Key::UpArrow => "Up",
 
-        Key::Command | Key::Super | Key::Windows | Key::Meta => "Meta",
+        Key::Command | Key::Super | Key::Windows | Key::Meta => "Super",
     })
 }
 impl KeyboardControllable for Enigo {


### PR DESCRIPTION
I'm not sure what key is actually being pressed with the string "meta", but from my testing only "Super" gives the expected keypress.