### PR TITLE
Fix move_mouse_to on windows

### DIFF
--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -48,10 +48,10 @@ fn keybd_event(flags: u32, vk: u16, scan: u16) {
 impl MouseControllable for Enigo {
     fn mouse_move_to(&mut self, x: i32, y: i32) {
         mouse_event(
-            MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE,
+            MOUSEEVENTF_MOVE | MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_VIRTUALDESK,
             0,
-            x * 65335 / unsafe { GetSystemMetrics(78) },
-            y * 65335 / unsafe { GetSystemMetrics(79) },
+            (x - unsafe { GetSystemMetrics(SM_XVIRTUALSCREEN) }) * 65535 / unsafe { GetSystemMetrics(SM_CXVIRTUALSCREEN) },
+            (y - unsafe { GetSystemMetrics(SM_YVIRTUALSCREEN) }) * 65535 / unsafe { GetSystemMetrics(SM_CYVIRTUALSCREEN) },
         );
     }
 


### PR DESCRIPTION
Update to #89, this fixes the mouse movement as described and keeps the use of the virtualscreen settings.

Edit: typo'd the commit but 🤷‍♂ 