### PR TITLE
Fix macOS up arrow virtual key

### DIFF
--- a/src/macos/keycodes.rs
+++ b/src/macos/keycodes.rs
@@ -52,4 +52,4 @@ pub const kVK_F1: u16 = 0x7A;
 pub const kVK_LeftArrow: u16 = 0x7B;
 pub const kVK_RightArrow: u16 = 0x7C;
 pub const kVK_DownArrow: u16 = 0x7D;
-pub const kVK_UpArrow: u16 = 0x7;
+pub const kVK_UpArrow: u16 = 0x7E;


### PR DESCRIPTION
kVK_UpArrow was set to 0x7 instead of 0x7E, resulting in `enigo.key_click(Key::UpArrow);` typing the letter x on my mac.