### PR TITLE
Add Hash derive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ extern crate serde_derive;
 extern crate serde;
 
 #[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Hash)]
 /// MouseButton represents a mouse button,
 /// and is used in for example
 /// [mouse_click](trait.MouseControllable.html#tymethod.mouse_click).
@@ -244,7 +244,7 @@ pub trait MouseControllable {
 /// For alphabetical keys, use Key::Layout for a system independent key.
 /// If a key is missing, you can use the raw keycode with Key::Raw.
 #[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Key {
     /// alt key on Linux and Windows (option key on macOS)
     Alt,


### PR DESCRIPTION
This PR simply adds a Hash derive so that Keys and MouseButtons can be used as keys in hashmaps

I run into this limitation while implementing a joystick - keyboard mapper (I need to keep a map of keys being pressed in memory)