### PR TITLE
Added Installation Instructions for other Distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,22 @@ Runtime dependencies
 Linux users may have to install libxdo-dev. For example, on Ubuntu:
 
 ```Bash
-apt install libxdo-dev
+apt-get install libxdo-dev
 ```
 On Arch: 
 
 ```Bash
 pacman -S xdotool
+```
+
+On Fedora:
+
+```Bash
+dnf install libX11-devel libxdo-devel
+```
+
+On Gentoo:
+
+```Bash
+emerge -a xdotool
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ for more look at examples
 Runtime dependencies
 --------------------
 
-Linux users may have to install libxdo-dev. For example, on Ubuntu:
+Linux users may have to install libxdo-dev. For example, on Debian-based distros:
 
 ```Bash
 apt-get install libxdo-dev


### PR DESCRIPTION
Similar to [this commit](https://github.com/DankDumpster/mouse-rs/commit/7b12c5e8371222a77b15c1a3b3f97a9afd1a003c#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5). The Gentoo instructions are confirmed to work, and although I'm unsure whether libx11-devel is needed for Fedora, it should work as well.