### PR TITLE
Fix a panic bug on key event on Windows.

### DIFF
--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -33,13 +33,15 @@ fn keybd_event(flags: u32, vk: u16, scan: u16) {
     let mut input = INPUT {
         type_: INPUT_KEYBOARD,
         u: unsafe {
-            transmute_copy(&KEYBDINPUT {
+            let mut input_u: INPUT_u = std::mem::zeroed();
+            *input_u.ki_mut() = KEYBDINPUT {
                 wVk: vk,
                 wScan: scan,
                 dwFlags: flags,
                 time: 0,
                 dwExtraInfo: 0,
-            })
+            };
+            input_u
         },
     };
     unsafe { SendInput(1, &mut input as LPINPUT, size_of::<INPUT>() as c_int) };


### PR DESCRIPTION
Hi.

Fixed following issue.
https://github.com/enigo-rs/enigo/issues/121

The policy of the fix was to follow the README of winapi-rs.

> ### How do I create an instance of a union?
>
> Use `std::mem::zeroed()` to create an instance of the union, and then assign the value you want using one of the variant methods.