### PR TITLE
Added Dependabot and Github Workflows to format, lint, build and test the crate

### DIFF
--- a/.github/actions/install_deps/action.yaml
+++ b/.github/actions/install_deps/action.yaml
@@ -1,0 +1,20 @@
+name: "Install_deps"
+description: "Installs the dependencies and updates the system"
+
+runs:
+  using: "composite"
+  steps:
+    - name:  Install dependencies
+      run:   |
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          sudo apt-get update -q -y && sudo apt-get upgrade -y && sudo apt-get install -y libxdo-dev 
+          echo "$RUNNER_OS"
+        elif [ "$RUNNER_OS" == "Windows" ]; then
+          echo "$RUNNER_OS"
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          echo "$RUNNER_OS"
+        else
+          echo "$RUNNER_OS not supported"
+          exit 1
+        fi
+      shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for cargo
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,53 @@
+name: build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  compile:
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+         # - "1.63.0"
+        platform:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install_deps
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo check
+  
+  compile_all_features:
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+         # - "1.63.0"
+        platform:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install_deps
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo check --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-         # - "1.63.0"
+          - "1.31.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-         # - "1.63.0"
+          - "1.31.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: docs
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  compile:
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+         # - "1.63.0"
+        platform:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install_deps
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo doc
+  
+  doc_all_features:
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+         # - "1.63.0"
+        platform:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install_deps
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo doc --all-features

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-         # - "1.63.0"
+          - "1.31.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-         # - "1.63.0"
+          - "1.31.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,53 @@
+name: examples
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  examples:
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+          - "1.63.0"
+        platform:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install_deps
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo check --examples
+
+  examples_all_features:
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+          - "1.63.0"
+        platform:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install_deps
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo check --examples --all-features

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.63.0"
+          - "1.31.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.63.0"
+          - "1.31.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,53 @@
+name: formatting
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  formatting:
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+          - "1.63.0"
+        platform:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install_deps
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt
+      - run: cargo fmt -- --check
+
+  lint:
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+          - "1.63.0"
+        platform:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install_deps
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: clippy
+      - run: cargo clippy --all-targets --all-features -- -D clippy::pedantic

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.63.0"
+          - "1.31.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.63.0"
+          - "1.31.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+name: test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+          - "1.63.0"
+        platform:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install_deps
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - name: Test
+        run: cargo test
+
+  test_all_features:
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly
+          - "1.63.0"
+        platform:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/install_deps
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - name: Test
+        run: cargo test --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.63.0"
+          - "1.31.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.63.0"
+          - "1.31.0"
         platform:
           - ubuntu-latest
           - windows-latest


### PR DESCRIPTION
In order to reduce the effort it takes to maintain this library, I added Dependabot and Github Workflows. Dependabot will automatically open a PR if a dependency or one of the used Github Actions is out of date. The Github Workflows will ensure that the code
- is properly formatted
- there are no clippy lints
- the library builds
- the examples build
- all tests are successful

This is done for all supported platforms (linux, macos, windows) and for three Rust versions. The Rust versions are:

- stable
- nightly
- the oldest version we support (I am not sure which version that is right now. I created https://github.com/enigo-rs/enigo/issues/127 to fix that)

The workflows can be manually started and they automatically run if a PR was raised