### PR TITLE
Increase MSRV to 1.58 and use Rust Edition 2021

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.31.0"
+          - "1.58.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.31.0"
+          - "1.58.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.31.0"
+          - "1.58.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.31.0"
+          - "1.58.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.31.0"
+          - "1.58.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.31.0"
+          - "1.58.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.31.0"
+          - "1.58.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.31.0"
+          - "1.58.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.31.0"
+          - "1.58.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.31.0"
+          - "1.58.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.14"
 authors = ["Dustin Bensing <dustin.bensing@googlemail.com>"]
 edition = "2018"
 build = "build.rs"
-rust-version = "1.31"
+rust-version = "1.58"
 
 description = "Enigo lets you control your mouse and keyboard in an abstract way on different operating systems (currently only Linux, macOS, Win – Redox and *BSD planned)"
 documentation = "https://docs.rs/enigo/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "enigo"
 version = "0.0.14"
 authors = ["Dustin Bensing <dustin.bensing@googlemail.com>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 rust-version = "1.58"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build status](https://travis-ci.org/enigo-rs/enigo.svg?branch=master)](https://travis-ci.org/enigo-rs/enigo)
 [![Build status](https://ci.appveyor.com/api/projects/status/6cd00pajx4tvvl3e?svg=true)](https://ci.appveyor.com/project/pythoneer/enigo-85xiy)
-![Rust version](https://img.shields.io/badge/rust--version-1.31-brightgreen.svg)
+![Rust version](https://img.shields.io/badge/rust--version-1.58-brightgreen.svg)
 [![Dependency status](https://deps.rs/repo/github/enigo-rs/enigo/status.svg)](https://deps.rs/repo/github/enigo-rs/enigo)
 
 [![Docs](https://docs.rs/enigo/badge.svg)](https://docs.rs/enigo)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,12 +62,12 @@ extern crate objc;
 #[cfg(target_os = "windows")]
 mod win;
 #[cfg(target_os = "windows")]
-pub use win::Enigo;
+pub use crate::win::Enigo;
 
 #[cfg(target_os = "macos")]
 mod macos;
 #[cfg(target_os = "macos")]
-pub use macos::Enigo;
+pub use crate::macos::Enigo;
 
 #[cfg(target_os = "linux")]
 mod linux;


### PR DESCRIPTION
In my tests, it seemed like the crate would build with 1.31 but on Windows and Mac the oldest version that can be used is actually 1.54. I took the liberty to raise the MSRV to 1.58 so that Rust Edition 2021 can be used and "Format strings can now capture arguments simply by writing `{ident}` in the string" ([release notes](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1580-2022-01-13)). Version 1.58 was released on 2022-01-13 so it is over a year old.

Context: Other important crates have a policy to support the last two stable releases and may raise it after 6 months (https://github.com/time-rs/time/discussions/535). 