### PR TITLE
Fix clippy lints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   compile:
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable
@@ -33,6 +34,7 @@ jobs:
   
   compile_all_features:
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   compile:
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable
@@ -33,6 +34,7 @@ jobs:
   
   doc_all_features:
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   examples:
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable
@@ -33,6 +34,7 @@ jobs:
 
   examples_all_features:
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   formatting:
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable
@@ -33,6 +34,7 @@ jobs:
 
   lint:
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable
@@ -33,6 +34,7 @@ jobs:
 
   test_all_features:
     strategy:
+      fail-fast: false
       matrix:
         rust:
           - stable

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 # Unreleased
 
 ## Changed
-- Windows: 'mouse_scroll_y' with a positive number scrolls down just like on the other platforms
-- Windows: replaced 'winapi' with the official 'windows' crate
+- Windows: `mouse_scroll_y` with a positive number scrolls down just like on the other platforms
+- Windows: replaced `winapi` with the official `windows` crate
 - Rust: Using Rust version 2021
 - Rust: Minimum supported Rust version (MSRV) is set in Cargo.toml
 - Rust: MSRV is 1.64
@@ -15,4 +15,4 @@
 - CI/CD: Github Workflows to make sure the code builds and the tests pass
 
 ## Fixed
-- Windows: panicked at 'cannot transmute_copy if U is larger than T' (https://github.com/enigo-rs/enigo/issues/121)
+- Windows: panicked at `cannot transmute_copy if U is larger than T` (https://github.com/enigo-rs/enigo/issues/121)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ On Gentoo:
 emerge -a xdotool
 ```
 
-# Migrating from a previous version
+## Migrating from a previous version
 
 Please have a look at our [changelog](CHANGES.md) to find out what you have to do, if you used a previous version.

--- a/build.rs
+++ b/build.rs
@@ -38,15 +38,14 @@ fn main() {
     let mut config = String::new();
     for lib in libraries.iter() {
         let libdir = match pkg_config::get_variable(lib, "libdir") {
-            Ok(libdir) => format!("Some(\"{}\")", libdir),
+            Ok(libdir) => format!("Some(\"{libdir}\")"),
             Err(_) => "None".to_string(),
         };
         config.push_str(&format!(
-            "pub const {}: Option<&'static str> = {};\n",
-            lib, libdir
+            "pub const {lib}: Option<&'static str> = {libdir};\n"
         ));
     }
-    let config = format!("pub mod config {{ pub mod libdir {{\n{}}}\n}}", config);
+    let config = format!("pub mod config {{ pub mod libdir {{\n{config}}}\n}}");
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("config.rs");
     let mut f = File::create(&dest_path).unwrap();

--- a/build.rs
+++ b/build.rs
@@ -46,7 +46,7 @@ fn main() {
     let config = format!("pub mod config {{ pub mod libdir {{\n{config}}}\n}}");
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("config.rs");
-    let mut f = File::create(&dest_path).unwrap();
+    let mut f = File::create(dest_path).unwrap();
     f.write_all(&config.into_bytes()).unwrap();
 
     let target = env::var("TARGET").unwrap();

--- a/build.rs
+++ b/build.rs
@@ -34,7 +34,7 @@ fn main() {
     ];
 
     let mut config = String::new();
-    for lib in libraries.iter() {
+    for lib in &libraries {
         let libdir = match pkg_config::get_variable(lib, "libdir") {
             Ok(libdir) => format!("Some(\"{libdir}\")"),
             Err(_) => "None".to_string(),

--- a/build.rs
+++ b/build.rs
@@ -5,8 +5,6 @@ fn main() {}
 fn main() {}
 
 #[cfg(target_os = "linux")]
-use pkg_config;
-#[cfg(target_os = "linux")]
 use std::env;
 #[cfg(target_os = "linux")]
 use std::fs::File;

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -13,7 +13,7 @@ fn main() {
     enigo.key_sequence("Hello World! ❤️");
 
     let time = now.elapsed();
-    println!("{:?}", time);
+    println!("{time:?}");
 
     // select all
     enigo.key_down(Key::Control);

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -34,21 +34,20 @@ pub enum ParseError {
     /// Use {+UNICODE} or {-UNICODE} to enable / disable unicode
     MissingUnicodeAction,
 }
-impl Error for ParseError {
-    fn description(&self) -> &str {
-        match *self {
+
+impl Error for ParseError {}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let text = match *self {
             Self::UnknownTag(_) => "Unknown tag",
             Self::UnexpectedOpen => "Unescaped open bracket ({) found inside tag name",
             Self::UnmatchedOpen => "Unmatched open bracket ({). No matching close (})",
             Self::UnmatchedClose => "Unmatched close bracket (}). No previous open ({)",
             Self::EmptyTag => "Empty tag",
             Self::MissingUnicodeAction => "Missing unicode action. {+UNICODE} or {-UNICODE}",
-        }
-    }
-}
-impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.description())
+        };
+        f.write_str(text)
     }
 }
 
@@ -148,44 +147,42 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
                         };
                         continue;
                     }
-                    tokens.append(&mut action.into_token(
-                        match key {
-                            "SHIFT" => Key::Shift,
-                            "CTRL" => Key::Control,
-                            "META" => Key::Meta,
-                            "ALT" => Key::Alt,
-                            "TAB" => Key::Tab,
-                            "BACKSPACE" => Key::Backspace,
-                            "CAPSLOCK" => Key::CapsLock,
-                            "CONTROL" => Key::Control,
-                            "DELETE" => Key::Delete,
-                            "DEL" => Key::Delete,
-                            "DOWNARROW" => Key::DownArrow,
-                            "END" => Key::End,
-                            "ESCAPE" => Key::Escape,
-                            "F1" => Key::F1,
-                            "F2" => Key::F2,
-                            "F3" => Key::F3,
-                            "F4" => Key::F4,
-                            "F5" => Key::F5,
-                            "F6" => Key::F6,
-                            "F7" => Key::F7,
-                            "F8" => Key::F8,
-                            "F9" => Key::F9,
-                            "F10" => Key::F10,
-                            "F11" => Key::F11,
-                            "F12" => Key::F12,
-                            "HOME" => Key::Home,
-                            "LEFTARROW" => Key::LeftArrow,
-                            "OPTION" => Key::Option,
-                            "PAGEDOWN" => Key::PageDown,
-                            "PAGEUP" => Key::PageUp,
-                            "RETURN" => Key::Return,
-                            "RIGHTARROW" => Key::RightArrow,
-                            "UPARROW" => Key::UpArrow,
-                            _ => return Err(ParseError::UnknownTag(tag)),
-                        }
-                    ));
+                    tokens.append(&mut action.into_token(match key {
+                        "SHIFT" => Key::Shift,
+                        "CTRL" => Key::Control,
+                        "META" => Key::Meta,
+                        "ALT" => Key::Alt,
+                        "TAB" => Key::Tab,
+                        "BACKSPACE" => Key::Backspace,
+                        "CAPSLOCK" => Key::CapsLock,
+                        "CONTROL" => Key::Control,
+                        "DELETE" => Key::Delete,
+                        "DEL" => Key::Delete,
+                        "DOWNARROW" => Key::DownArrow,
+                        "END" => Key::End,
+                        "ESCAPE" => Key::Escape,
+                        "F1" => Key::F1,
+                        "F2" => Key::F2,
+                        "F3" => Key::F3,
+                        "F4" => Key::F4,
+                        "F5" => Key::F5,
+                        "F6" => Key::F6,
+                        "F7" => Key::F7,
+                        "F8" => Key::F8,
+                        "F9" => Key::F9,
+                        "F10" => Key::F10,
+                        "F11" => Key::F11,
+                        "F12" => Key::F12,
+                        "HOME" => Key::Home,
+                        "LEFTARROW" => Key::LeftArrow,
+                        "OPTION" => Key::Option,
+                        "PAGEDOWN" => Key::PageDown,
+                        "PAGEUP" => Key::PageUp,
+                        "RETURN" => Key::Return,
+                        "RIGHTARROW" => Key::RightArrow,
+                        "UPARROW" => Key::UpArrow,
+                        _ => return Err(ParseError::UnknownTag(tag)),
+                    }));
                 }
                 None => return Err(ParseError::UnmatchedOpen),
             }
@@ -216,10 +213,7 @@ impl Action {
         match self {
             Self::Down => vec![Token::KeyDown(key)],
             Self::Up => vec![Token::KeyUp(key)],
-            Self::Press => vec![
-                Token::KeyDown(key),
-                Token::KeyUp(key),
-            ],
+            Self::Press => vec![Token::KeyDown(key), Token::KeyUp(key)],
         }
     }
 }

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -82,6 +82,7 @@ enum Token {
     KeyDown(Key),
 }
 
+#[allow(clippy::too_many_lines)]
 fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
     fn flush(tokens: &mut Vec<Token>, buffer: String, unicode: bool) {
         if !buffer.is_empty() {
@@ -137,10 +138,10 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
                         },
                         None => return Err(ParseError::EmptyTag),
                     };
-                    let key = if action != Action::Press {
-                        &tag[1..]
-                    } else {
+                    let key = if action == Action::Press {
                         &tag
+                    } else {
+                        &tag[1..]
                     };
                     if tag == "UNICODE" {
                         unicode = match action {
@@ -151,16 +152,11 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
                         continue;
                     }
                     tokens.append(&mut action.into_token(match key {
-                        "SHIFT" => Key::Shift,
-                        "CTRL" => Key::Control,
-                        "META" => Key::Meta,
                         "ALT" => Key::Alt,
-                        "TAB" => Key::Tab,
                         "BACKSPACE" => Key::Backspace,
                         "CAPSLOCK" => Key::CapsLock,
-                        "CONTROL" => Key::Control,
-                        "DELETE" => Key::Delete,
-                        "DEL" => Key::Delete,
+                        "CTRL" | "CONTROL" => Key::Control,
+                        "DELETE" | "DEL" => Key::Delete,
                         "DOWNARROW" => Key::DownArrow,
                         "END" => Key::End,
                         "ESCAPE" => Key::Escape,
@@ -176,13 +172,24 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
                         "F10" => Key::F10,
                         "F11" => Key::F11,
                         "F12" => Key::F12,
+                        "F13" => Key::F13,
+                        "F14" => Key::F14,
+                        "F15" => Key::F15,
+                        "F16" => Key::F16,
+                        "F17" => Key::F17,
+                        "F18" => Key::F18,
+                        "F19" => Key::F19,
+                        "F20" => Key::F20,
                         "HOME" => Key::Home,
                         "LEFTARROW" => Key::LeftArrow,
+                        "META" => Key::Meta,
                         "OPTION" => Key::Option,
                         "PAGEDOWN" => Key::PageDown,
                         "PAGEUP" => Key::PageUp,
                         "RETURN" => Key::Return,
                         "RIGHTARROW" => Key::RightArrow,
+                        "SHIFT" => Key::Shift,
+                        "TAB" => Key::Tab,
                         "UPARROW" => Key::UpArrow,
                         _ => return Err(ParseError::UnknownTag(tag)),
                     }));
@@ -212,6 +219,7 @@ enum Action {
 }
 
 impl Action {
+    #[allow(clippy::wrong_self_convention)]
     pub fn into_token(&self, key: Key) -> Vec<Token> {
         match self {
             Self::Down => vec![Token::KeyDown(key)],

--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -52,6 +52,9 @@ impl fmt::Display for ParseError {
 }
 
 /// Evaluate the DSL. This tokenizes the input and presses the keys.
+/// # Errors
+///
+/// Will return [`ParseError`] if the input cannot be parsed
 pub fn eval<K>(enigo: &mut K, input: &str) -> Result<(), ParseError>
 where
     K: KeyboardControllable,
@@ -80,12 +83,6 @@ enum Token {
 }
 
 fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
-    let mut unicode = false;
-
-    let mut tokens = Vec::new();
-    let mut buffer = String::new();
-    let mut iter = input.chars().peekable();
-
     fn flush(tokens: &mut Vec<Token>, buffer: String, unicode: bool) {
         if !buffer.is_empty() {
             if unicode {
@@ -95,6 +92,12 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
             }
         }
     }
+
+    let mut unicode = false;
+
+    let mut tokens = Vec::new();
+    let mut buffer = String::new();
+    let mut iter = input.chars().peekable();
 
     while let Some(c) = iter.next() {
         if c == '{' {
@@ -111,14 +114,14 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
                             Some('{') => match iter.peek() {
                                 Some(&'{') => {
                                     iter.next();
-                                    c = '{'
+                                    c = '{';
                                 }
                                 _ => return Err(ParseError::UnexpectedOpen),
                             },
                             Some('}') => match iter.peek() {
                                 Some(&'}') => {
                                     iter.next();
-                                    c = '}'
+                                    c = '}';
                                 }
                                 _ => break,
                             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,13 +24,13 @@
 //! interfaces unaccessible by a public API or scripting language.
 //!
 //! For the keyboard there are currently two modes you can use. The first mode
-//! is represented by the [key_sequence]() function
-//! its purpose is to simply write unicode characters. This is independent of
-//! the keyboardlayout. Please note that
+//! is represented by the [`key_sequence`](KeyboardControllable::key_sequence)
+//! function its purpose is to simply write unicode characters. This is
+//! independent of the keyboard layout. Please note that
 //! you're not be able to use modifier keys like Control
 //! to influence the outcome. If you want to use modifier keys to e.g.
-//! copy/paste
-//! use the Layout variant. Please note that this is indeed layout dependent.
+//! copy/paste, use the Layout variant. Please note that this is indeed layout
+//! dependent.
 
 //! # Examples
 //! ```no_run
@@ -51,7 +51,12 @@
 //! enigo.mouse_up(MouseButton::Left);
 //! enigo.key_sequence("hello world");
 //! ```
-#![deny(missing_docs)]
+#![deny(clippy::pedantic)]
+#![allow(clippy::cast_lossless)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_sign_loss)]
+#![allow(deprecated)]
 
 #[cfg(target_os = "macos")]
 #[macro_use]
@@ -86,9 +91,9 @@ extern crate serde;
 
 #[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-/// MouseButton represents a mouse button,
+/// [`MouseButton`] represents a mouse button,
 /// and is used in for example
-/// [mouse_click](trait.MouseControllable.html#tymethod.mouse_click).
+/// [`MouseControllable::mouse_click`].
 /// WARNING: Types with the prefix Scroll
 /// IS NOT intended to be used, and may not work on
 /// all operating systems.
@@ -151,14 +156,12 @@ pub trait MouseControllable {
     /// Push down one of the mouse buttons
     ///
     /// Push down the mouse button specified by the parameter `button` of
-    /// type [MouseButton](enum.MouseButton.html)
+    /// type [`MouseButton`]
     /// and holds it until it is released by
-    /// [mouse_up](trait.MouseControllable.html#tymethod.mouse_up).
-    /// Calls to [mouse_move_to](trait.MouseControllable.html#tymethod.
-    /// mouse_move_to) or
-    /// [mouse_move_relative](trait.MouseControllable.html#tymethod.
-    /// mouse_move_relative)
-    /// will work like expected and will e.g. drag widgets or highlight text.
+    /// [`MouseControllable::mouse_up`](.
+    /// Calls to [`MouseControllable::mouse_move_to`] or
+    /// [`MouseControllable::mouse_move_relative`] will
+    /// work like expected and will e.g. drag widgets or highlight text.
     ///
     /// # Example
     ///
@@ -172,12 +175,11 @@ pub trait MouseControllable {
     /// Lift up a pushed down mouse button
     ///
     /// Lift up a previously pushed down button (by invoking
-    /// [mouse_down](trait.MouseControllable.html#tymethod.mouse_down)).
+    /// [`MouseControllable::mouse_down`]).
     /// If the button was not pushed down or consecutive calls without
-    /// invoking [mouse_down](trait.MouseControllable.html#tymethod.mouse_down)
-    /// will emit lift up events. It depends on the
-    /// operating system whats actually happening – my guess is it will just
-    /// get ignored.
+    /// invoking [`MouseControllable::mouse_down`] will emit lift up
+    /// events. It depends on the operating system whats actually happening
+    /// – my guess is it will just get ignored.
     ///
     /// # Example
     ///
@@ -191,9 +193,8 @@ pub trait MouseControllable {
     /// Click a mouse button
     ///
     /// it's essentially just a consecutive invocation of
-    /// [mouse_down](trait.MouseControllable.html#tymethod.mouse_down) followed
-    /// by a [mouse_up](trait.MouseControllable.html#tymethod.mouse_up). Just
-    /// for
+    /// [`MouseControllable::mouse_down`]
+    /// followed by a [`MouseControllable::mouse_up`]. Just for
     /// convenience.
     ///
     /// # Example
@@ -241,8 +242,8 @@ pub trait MouseControllable {
 }
 
 /// A key on the keyboard.
-/// For alphabetical keys, use Key::Layout for a system independent key.
-/// If a key is missing, you can use the raw keycode with Key::Raw.
+/// For alphabetical keys, use [`Key::Layout`] for a system independent key.
+/// If a key is missing, you can use the raw keycode with [`Key::Raw`].
 #[cfg_attr(feature = "with_serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Key {
@@ -355,7 +356,12 @@ pub trait KeyboardControllable {
         self.key_sequence_parse_try(sequence)
             .expect("Could not parse sequence");
     }
-    /// Same as key_sequence_parse except returns any errors
+
+    /// Same as [`KeyboardControllable::key_sequence_parse`] except returns any
+    /// errors
+    ///  # Errors
+    ///
+    /// Returns a [`dsl::ParseError`] if the sequence cannot be parsed
     fn key_sequence_parse_try(&mut self, sequence: &str) -> Result<(), dsl::ParseError>
     where
         Self: Sized,
@@ -383,13 +389,12 @@ pub trait KeyboardControllable {
     fn key_down(&mut self, key: Key);
 
     /// release a given key formally pressed down by
-    /// [key_down](trait.KeyboardControllable.html#tymethod.key_down)
+    /// [`KeyboardControllable::key_down`]
     fn key_up(&mut self, key: Key);
 
-    /// Much like the
-    /// [key_down](trait.KeyboardControllable.html#tymethod.key_down) and
-    /// [key_up](trait.KeyboardControllable.html#tymethod.key_up)
-    /// function they're just invoked consecutively
+    /// Much like the [`KeyboardControllable::key_down`] and
+    /// [`KeyboardControllable::key_up`] function they're just invoked
+    /// consecutively
     fn key_click(&mut self, key: Key);
 }
 
@@ -402,6 +407,7 @@ impl Enigo {
     /// use enigo::*;
     /// let mut enigo = Enigo::new();
     /// ```
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -124,14 +124,12 @@ impl MouseControllable for Enigo {
         }
     }
     fn mouse_scroll_x(&mut self, length: i32) {
-        let button;
         let mut length = length;
-
-        if length < 0 {
-            button = MouseButton::ScrollLeft;
+        let button = if length < 0 {
+            MouseButton::ScrollLeft
         } else {
-            button = MouseButton::ScrollRight;
-        }
+            MouseButton::ScrollRight
+        };
 
         if length < 0 {
             length = -length;
@@ -142,14 +140,12 @@ impl MouseControllable for Enigo {
         }
     }
     fn mouse_scroll_y(&mut self, length: i32) {
-        let button;
         let mut length = length;
-
-        if length < 0 {
-            button = MouseButton::ScrollUp;
+        let button = if length < 0 {
+            MouseButton::ScrollUp
         } else {
-            button = MouseButton::ScrollDown;
-        }
+            MouseButton::ScrollDown
+        };
 
         if length < 0 {
             length = -length;

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -81,6 +81,7 @@ impl Enigo {
     /// Get the delay per keypress.
     /// Default value is 12000.
     /// This is Linux-specific.
+    #[must_use]
     pub fn delay(&self) -> u64 {
         self.delay
     }
@@ -163,7 +164,6 @@ fn keysequence<'a>(key: Key) -> Cow<'a, str> {
     if let Key::Raw(k) = key {
         return Cow::Owned(format!("{k}"));
     }
-    #[allow(deprecated)]
     // I mean duh, we still need to support deprecated keys until they're removed
     Cow::Borrowed(match key {
         Key::Alt => "Alt",
@@ -195,19 +195,17 @@ fn keysequence<'a>(key: Key) -> Cow<'a, str> {
         Key::F19 => "F19",
         Key::F20 => "F20",
         Key::Home => "Home",
-        Key::Layout(_) => unreachable!(),
         Key::LeftArrow => "Left",
         Key::Option => "Option",
         Key::PageDown => "Page_Down",
         Key::PageUp => "Page_Up",
-        Key::Raw(_) => unreachable!(),
         Key::Return => "Return",
         Key::RightArrow => "Right",
         Key::Shift => "Shift",
         Key::Space => "space",
         Key::Tab => "Tab",
         Key::UpArrow => "Up",
-
+        Key::Layout(_) | Key::Raw(_) => unreachable!(),
         Key::Command | Key::Super | Key::Windows | Key::Meta => "Super",
     })
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -165,7 +165,7 @@ fn keysequence<'a>(key: Key) -> Cow<'a, str> {
         return Cow::Owned(format!("U{:X}", c as u32));
     }
     if let Key::Raw(k) = key {
-        return Cow::Owned(format!("{}", k as u16));
+        return Cow::Owned(format!("{k}"));
     }
     #[allow(deprecated)]
     // I mean duh, we still need to support deprecated keys until they're removed

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -1,15 +1,26 @@
+use std::os::raw::{c_char, c_int, c_uchar, c_uint, c_ulong, c_ushort, c_void};
+use std::{thread, time};
+
 use core_graphics;
 
-// TODO(dustin): use only the things i need
-
-use self::core_graphics::display::*;
-use self::core_graphics::event::*;
-use self::core_graphics::event_source::*;
-
-use crate::macos::keycodes::*;
-use crate::{Key, KeyboardControllable, MouseButton, MouseControllable};
 use objc::runtime::Class;
-use std::os::raw::*;
+
+use self::core_graphics::display::{
+    CFIndex, CFRelease, CGDisplayPixelsHigh, CGDisplayPixelsWide, CGMainDisplayID, CGPoint,
+};
+use self::core_graphics::event::{
+    CGEvent, CGEventTapLocation, CGEventType, CGKeyCode, CGMouseButton,
+};
+use self::core_graphics::event_source::{CGEventSource, CGEventSourceRef, CGEventSourceStateID};
+
+use crate::macos::keycodes::{
+    kVK_CapsLock, kVK_Command, kVK_Control, kVK_Delete, kVK_DownArrow, kVK_End, kVK_Escape, kVK_F1,
+    kVK_F10, kVK_F11, kVK_F12, kVK_F13, kVK_F14, kVK_F15, kVK_F16, kVK_F17, kVK_F18, kVK_F19,
+    kVK_F2, kVK_F20, kVK_F3, kVK_F4, kVK_F5, kVK_F6, kVK_F7, kVK_F8, kVK_F9, kVK_ForwardDelete,
+    kVK_Home, kVK_LeftArrow, kVK_Option, kVK_PageDown, kVK_PageUp, kVK_Return, kVK_RightArrow,
+    kVK_Shift, kVK_Space, kVK_Tab, kVK_UpArrow,
+};
+use crate::{Key, KeyboardControllable, MouseButton, MouseControllable};
 
 // required for pressedMouseButtons on NSEvent
 #[link(name = "AppKit", kind = "framework")]
@@ -368,8 +379,6 @@ impl KeyboardControllable for Enigo {
 
     fn key_click(&mut self, key: Key) {
         let keycode = self.key_to_keycode(key);
-
-        use std::{thread, time};
         thread::sleep(time::Duration::from_millis(20));
         let event = CGEvent::new_keyboard_event(self.event_source.clone(), keycode, true)
             .expect("Failed creating event");
@@ -382,7 +391,6 @@ impl KeyboardControllable for Enigo {
     }
 
     fn key_down(&mut self, key: Key) {
-        use std::{thread, time};
         thread::sleep(time::Duration::from_millis(20));
         let event =
             CGEvent::new_keyboard_event(self.event_source.clone(), self.key_to_keycode(key), true)
@@ -391,7 +399,6 @@ impl KeyboardControllable for Enigo {
     }
 
     fn key_up(&mut self, key: Key) {
-        use std::{thread, time};
         thread::sleep(time::Duration::from_millis(20));
         let event =
             CGEvent::new_keyboard_event(self.event_source.clone(), self.key_to_keycode(key), false)
@@ -407,6 +414,7 @@ impl Enigo {
     }
 
     /// Fetches the `(width, height)` in pixels of the main display
+    #[must_use]
     pub fn main_display_size() -> (usize, usize) {
         let display_id = unsafe { CGMainDisplayID() };
         let width = unsafe { CGDisplayPixelsWide(display_id) };
@@ -416,8 +424,9 @@ impl Enigo {
 
     /// Returns the current mouse location in Cocoa coordinates which have Y
     /// inverted from the Carbon coordinates used in the rest of the API.
-    /// This function exists so that mouse_move_relative only has to fetch
-    /// the screen size once.
+    /// This function exists so that [`Enigo::mouse_move_relative`] only has to
+    /// fetch the screen size once.
+    #[must_use]
     fn mouse_location_raw_coords() -> (i32, i32) {
         let ns_event = Class::get("NSEvent").unwrap();
         let pt: NSPoint = unsafe { msg_send![ns_event, mouseLocation] };
@@ -425,6 +434,7 @@ impl Enigo {
     }
 
     /// The mouse coordinates in points, only works on the main display
+    #[must_use]
     pub fn mouse_location() -> (i32, i32) {
         let (x, y_inv) = Self::mouse_location_raw_coords();
         let (_, display_height) = Self::main_display_size();
@@ -432,10 +442,9 @@ impl Enigo {
     }
 
     fn key_to_keycode(&self, key: Key) -> CGKeyCode {
-        #[allow(deprecated)]
         // I mean duh, we still need to support deprecated keys until they're removed
         match key {
-            Key::Alt => kVK_Option,
+            Key::Alt | Key::Option => kVK_Option,
             Key::Backspace => kVK_Delete,
             Key::CapsLock => kVK_CapsLock,
             Key::Control => kVK_Control,
@@ -465,7 +474,6 @@ impl Enigo {
             Key::F20 => kVK_F20,
             Key::Home => kVK_Home,
             Key::LeftArrow => kVK_LeftArrow,
-            Key::Option => kVK_Option,
             Key::PageDown => kVK_PageDown,
             Key::PageUp => kVK_PageUp,
             Key::Return => kVK_Return,
@@ -475,13 +483,12 @@ impl Enigo {
             Key::Tab => kVK_Tab,
             Key::UpArrow => kVK_UpArrow,
             Key::Raw(raw_keycode) => raw_keycode,
-            Key::Layout(c) => self.get_layoutdependent_keycode(c.to_string()),
-
+            Key::Layout(c) => self.get_layoutdependent_keycode(&c.to_string()),
             Key::Super | Key::Command | Key::Windows | Key::Meta => kVK_Command,
         }
     }
 
-    fn get_layoutdependent_keycode(&self, string: String) -> CGKeyCode {
+    fn get_layoutdependent_keycode(&self, string: &str) -> CGKeyCode {
         let mut pressed_keycode = 0;
 
         // loop through every keycode (0 - 127)
@@ -530,6 +537,7 @@ impl Enigo {
         None
     }
 
+    #[allow(clippy::unused_self)]
     fn create_string_for_key(&self, keycode: u16, modifier: u32) -> CFStringRef {
         let current_keyboard = unsafe { TISCopyCurrentKeyboardInputSource() };
         let layout_data = unsafe {

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -365,8 +365,9 @@ impl MouseControllable for Enigo {
 impl KeyboardControllable for Enigo {
     fn key_sequence(&mut self, sequence: &str) {
         // NOTE(dustin): This is a fix for issue https://github.com/enigo-rs/enigo/issues/68
-        // TODO(dustin): This could be improved by aggregating 20 bytes worth of graphemes at a time
-        // but i am unsure what would happen for grapheme clusters greater than 20 bytes ...
+        // TODO(dustin): This could be improved by aggregating 20 bytes worth of
+        // graphemes at a time but i am unsure what would happen for grapheme
+        // clusters greater than 20 bytes ...
         use unicode_segmentation::UnicodeSegmentation;
         let clusters = UnicodeSegmentation::graphemes(sequence, true).collect::<Vec<&str>>();
         for cluster in clusters {

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -1,3 +1,5 @@
+use std::{mem::size_of, thread, time};
+
 use windows::Win32::Foundation::POINT;
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     MapVirtualKeyW, SendInput, VkKeyScanW, INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT,
@@ -12,9 +14,14 @@ use windows::Win32::UI::WindowsAndMessaging::{
     SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN,
 };
 
-use crate::win::keycodes::*;
+use crate::win::keycodes::{
+    EVK_BACK, EVK_CAPITAL, EVK_DELETE, EVK_DOWN, EVK_END, EVK_ESCAPE, EVK_F1, EVK_F10, EVK_F11,
+    EVK_F12, EVK_F13, EVK_F14, EVK_F15, EVK_F16, EVK_F17, EVK_F18, EVK_F19, EVK_F2, EVK_F20,
+    EVK_F3, EVK_F4, EVK_F5, EVK_F6, EVK_F7, EVK_F8, EVK_F9, EVK_HOME, EVK_LCONTROL, EVK_LEFT,
+    EVK_LWIN, EVK_MENU, EVK_NEXT, EVK_PRIOR, EVK_RETURN, EVK_RIGHT, EVK_SHIFT, EVK_SPACE, EVK_TAB,
+    EVK_UP,
+};
 use crate::{Key, KeyboardControllable, MouseButton, MouseControllable};
-use std::mem::*;
 
 /// The main struct for handling the event emitting
 #[derive(Default)]
@@ -193,6 +200,7 @@ impl Enigo {
     /// use enigo::*;
     /// let mut size = Enigo::main_display_size();
     /// ```
+    #[must_use]
     pub fn main_display_size() -> (usize, usize) {
         let w = unsafe { GetSystemMetrics(SM_CXSCREEN) as usize };
         let h = unsafe { GetSystemMetrics(SM_CYSCREEN) as usize };
@@ -207,6 +215,7 @@ impl Enigo {
     /// use enigo::*;
     /// let mut location = Enigo::mouse_location();
     /// ```
+    #[must_use]
     pub fn mouse_location() -> (i32, i32) {
         let mut point = POINT { x: 0, y: 0 };
         let result = unsafe { GetCursorPos(&mut point) };
@@ -218,12 +227,12 @@ impl Enigo {
     }
 
     fn unicode_key_click(&self, unicode_char: u16) {
-        use std::{thread, time};
         self.unicode_key_down(unicode_char);
         thread::sleep(time::Duration::from_millis(20));
         self.unicode_key_up(unicode_char);
     }
 
+    #[allow(clippy::unused_self)]
     fn unicode_key_down(&self, unicode_char: u16) {
         keybd_event(
             KEYEVENTF_UNICODE,
@@ -232,6 +241,7 @@ impl Enigo {
         );
     }
 
+    #[allow(clippy::unused_self)]
     fn unicode_key_up(&self, unicode_char: u16) {
         keybd_event(
             KEYEVENTF_UNICODE | KEYEVENTF_KEYUP,
@@ -245,10 +255,10 @@ impl Enigo {
         // wrongly typed with i32 instead of i16 use the
         // ones provided by win/keycodes.rs that are prefixed
         // with an 'E' infront of the original name
-        #[allow(deprecated)]
+
         // I mean duh, we still need to support deprecated keys until they're removed
         match key {
-            Key::Alt => EVK_MENU,
+            Key::Alt | Key::Option => EVK_MENU,
             Key::Backspace => EVK_BACK,
             Key::CapsLock => EVK_CAPITAL,
             Key::Control => EVK_LCONTROL,
@@ -278,7 +288,6 @@ impl Enigo {
             Key::F20 => EVK_F20,
             Key::Home => EVK_HOME,
             Key::LeftArrow => EVK_LEFT,
-            Key::Option => EVK_MENU,
             Key::PageDown => EVK_NEXT,
             Key::PageUp => EVK_PRIOR,
             Key::Return => EVK_RETURN,
@@ -287,10 +296,8 @@ impl Enigo {
             Key::Space => EVK_SPACE,
             Key::Tab => EVK_TAB,
             Key::UpArrow => EVK_UP,
-
             Key::Raw(raw_keycode) => raw_keycode,
-            Key::Layout(c) => self.get_layoutdependent_keycode(c.to_string()),
-            //_ => 0,
+            Key::Layout(c) => self.get_layoutdependent_keycode(&c.to_string()),
             Key::Super | Key::Command | Key::Windows | Key::Meta => EVK_LWIN,
         }
     }
@@ -305,7 +312,8 @@ impl Enigo {
         }
     }
 
-    fn get_layoutdependent_keycode(&self, string: String) -> u16 {
+    #[allow(clippy::unused_self)]
+    fn get_layoutdependent_keycode(&self, string: &str) -> u16 {
         let mut buffer = [0; 2];
         // get the first char from the string ignore the rest
         // ensure its not a multybyte char

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -322,10 +322,8 @@ impl Enigo {
             .next()
             .expect("no valid input") //TODO(dustin): no panic here make an error
             .encode_utf16(&mut buffer);
-        if utf16.len() != 1 {
-            // TODO(dustin) don't panic here use an apropriate errors
-            panic!("this char is not allowd");
-        }
+        // TODO(dustin) don't panic here use an apropriate errors
+        assert!(!(utf16.len() != 1), "this char is not allowd");
         // NOTE VkKeyScanW uses the current keyboard layout
         // to specify a layout use VkKeyScanExW and GetKeyboardLayout
         // or load one with LoadKeyboardLayoutW

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -159,7 +159,6 @@ impl KeyboardControllable for Enigo {
 
     fn key_click(&mut self, key: Key) {
         let scancode = self.key_to_scancode(key);
-        use std::{thread, time};
         keybd_event(
             KEYEVENTF_SCANCODE,
             windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY(0),
@@ -323,7 +322,7 @@ impl Enigo {
             .expect("no valid input") //TODO(dustin): no panic here make an error
             .encode_utf16(&mut buffer);
         // TODO(dustin) don't panic here use an apropriate errors
-        assert!(!(utf16.len() != 1), "this char is not allowd");
+        assert!(utf16.len() == 1, "this char is not allowed");
         // NOTE VkKeyScanW uses the current keyboard layout
         // to specify a layout use VkKeyScanExW and GetKeyboardLayout
         // or load one with LoadKeyboardLayoutW


### PR DESCRIPTION
There are a number of clippy lints that cause the Github Workflow "format" to fail. These commits fix the lints.

I have also enabled the pedantic clippy lints to get notified about all possible lints.