### PR TITLE
Move from winapi to the windows crate (#137)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.58.0"
+          - "1.64.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.58.0"
+          - "1.64.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.58.0"
+          - "1.64.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.58.0"
+          - "1.64.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.58.0"
+          - "1.64.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.58.0"
+          - "1.64.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.58.0"
+          - "1.64.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.58.0"
+          - "1.64.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.58.0"
+          - "1.64.0"
         platform:
           - ubuntu-latest
           - windows-latest
@@ -37,7 +37,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.58.0"
+          - "1.64.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.14"
 authors = ["Dustin Bensing <dustin.bensing@googlemail.com>"]
 edition = "2021"
 build = "build.rs"
-rust-version = "1.58"
+rust-version = "1.64"
 
 description = "Enigo lets you control your mouse and keyboard in an abstract way on different operating systems (currently only Linux, macOS, Win – Redox and *BSD planned)"
 documentation = "https://docs.rs/enigo/"
@@ -31,7 +31,7 @@ windows = { version = "0.44.0", features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Input_KeyboardAndMouse",
-]}
+] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,11 @@ serde_derive = { version = "1.0.102", optional = true }
 with_serde = ["serde", "serde_derive"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.8", features = ["winuser"] }
+windows = { version = "0.44.0", features = [
+    "Win32_Foundation",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Input_KeyboardAndMouse",
+]}
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.18.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build status](https://travis-ci.org/enigo-rs/enigo.svg?branch=master)](https://travis-ci.org/enigo-rs/enigo)
 [![Build status](https://ci.appveyor.com/api/projects/status/6cd00pajx4tvvl3e?svg=true)](https://ci.appveyor.com/project/pythoneer/enigo-85xiy)
-![Rust version](https://img.shields.io/badge/rust--version-1.58-brightgreen.svg)
+![Rust version](https://img.shields.io/badge/rust--version-1.64-brightgreen.svg)
 [![Dependency status](https://deps.rs/repo/github/enigo-rs/enigo/status.svg)](https://deps.rs/repo/github/enigo-rs/enigo)
 
 [![Docs](https://docs.rs/enigo/badge.svg)](https://docs.rs/enigo)


### PR DESCRIPTION
Here is my attempt at converting to the windows-rs crate. I am not entirely sure how this is supposed to work under the hood so I've made a couple assumptions in the code.

I had to replace the result "check if not 0" code with this block. I'm open to suggestions.

        if result.as_bool() {
            (point.x, point.y)
        } else {
            (0, 0)
        }

This function now needs a VIRTUAL_KEY instead of a u16 so I had to wrap the 0. Again, anyone familiar with the windows-rs crate can correct this. That being said, everything seems to work on my Windows machine.

        keybd_event(
            KEYEVENTF_KEYUP | KEYEVENTF_SCANCODE,
            windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY(0),
            scancode,
        );

