### PR TITLE
Fix the y scroll direction on Window

### DIFF
--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -121,7 +121,7 @@ impl MouseControllable for Enigo {
     }
 
     fn mouse_scroll_y(&mut self, length: i32) {
-        mouse_event(MOUSEEVENTF_WHEEL, length * 120, 0, 0);
+        mouse_event(MOUSEEVENTF_WHEEL, length * -120, 0, 0);
     }
 }
 
@@ -184,7 +184,8 @@ impl KeyboardControllable for Enigo {
 }
 
 impl Enigo {
-    /// Gets the (width, height) of the main display in screen coordinates (pixels).
+    /// Gets the (width, height) of the main display in screen coordinates
+    /// (pixels).
     ///
     /// # Example
     ///


### PR DESCRIPTION
Scrolling in the y direction was inverted on Windows. This PR makes the behavior consistent across platforms
fixes https://github.com/enigo-rs/enigo/issues/117)