### PR TITLE
Windows, macOS: Implement the missing parts in the mouse_down and mouse_up fn

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,3 +17,4 @@
 ## Fixed
 - Windows: panicked at `cannot transmute_copy if U is larger than T` (https://github.com/enigo-rs/enigo/issues/121)
 - Windows: Inconsistent behavior between the `mouse_move_relative` and `mouse_move_to` functions (https://github.com/enigo-rs/enigo/issues/91)
+- Windows, macOS: Stop panicking when `mouse_down` or `mouse_up` is called with either of `MouseButton::ScrollUp`, `MouseButton::ScrollDown`, `MouseButton::ScrollLeft`, `MouseButton::ScrollRight` and instead scroll

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -279,7 +279,10 @@ impl MouseControllable for Enigo {
             MouseButton::Left => (CGMouseButton::Left, CGEventType::LeftMouseDown),
             MouseButton::Middle => (CGMouseButton::Center, CGEventType::OtherMouseDown),
             MouseButton::Right => (CGMouseButton::Right, CGEventType::RightMouseDown),
-            _ => unimplemented!(),
+            MouseButton::ScrollUp => return self.mouse_scroll_x(-1),
+            MouseButton::ScrollDown => return self.mouse_scroll_x(1),
+            MouseButton::ScrollLeft => return self.mouse_scroll_y(-1),
+            MouseButton::ScrollRight => return self.mouse_scroll_y(1),
         };
         let dest = CGPoint::new(current_x as f64, current_y as f64);
         let event =
@@ -293,7 +296,13 @@ impl MouseControllable for Enigo {
             MouseButton::Left => (CGMouseButton::Left, CGEventType::LeftMouseUp),
             MouseButton::Middle => (CGMouseButton::Center, CGEventType::OtherMouseUp),
             MouseButton::Right => (CGMouseButton::Right, CGEventType::RightMouseUp),
-            _ => unimplemented!(),
+            MouseButton::ScrollUp
+            | MouseButton::ScrollDown
+            | MouseButton::ScrollLeft
+            | MouseButton::ScrollRight => {
+                println!("On macOS the mouse_up function has no effect when called with one of the Scroll buttons");
+                return;
+            }
         };
         let dest = CGPoint::new(current_x as f64, current_y as f64);
         let event =

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -97,7 +97,10 @@ impl MouseControllable for Enigo {
                 MouseButton::Left => MOUSEEVENTF_LEFTDOWN,
                 MouseButton::Middle => MOUSEEVENTF_MIDDLEDOWN,
                 MouseButton::Right => MOUSEEVENTF_RIGHTDOWN,
-                _ => unimplemented!(),
+                MouseButton::ScrollUp => return self.mouse_scroll_x(-1),
+                MouseButton::ScrollDown => return self.mouse_scroll_x(1),
+                MouseButton::ScrollLeft => return self.mouse_scroll_y(-1),
+                MouseButton::ScrollRight => return self.mouse_scroll_y(1),
             },
             0,
             0,
@@ -111,7 +114,13 @@ impl MouseControllable for Enigo {
                 MouseButton::Left => MOUSEEVENTF_LEFTUP,
                 MouseButton::Middle => MOUSEEVENTF_MIDDLEUP,
                 MouseButton::Right => MOUSEEVENTF_RIGHTUP,
-                _ => unimplemented!(),
+                MouseButton::ScrollUp
+                | MouseButton::ScrollDown
+                | MouseButton::ScrollLeft
+                | MouseButton::ScrollRight => {
+                    println!("On Windows the mouse_up function has no effect when called with one of the Scroll buttons");
+                    return;
+                }
             },
             0,
             0,


### PR DESCRIPTION
Fixes https://github.com/enigo-rs/enigo/issues/147