### PR TITLE
Fix inconsistent pixel units between move_mouse_to and move_mouse_relative

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,3 +16,4 @@
 
 ## Fixed
 - Windows: panicked at `cannot transmute_copy if U is larger than T` (https://github.com/enigo-rs/enigo/issues/121)
+- Windows: Inconsistent behavior between the `mouse_move_relative` and `mouse_move_to` functions (https://github.com/enigo-rs/enigo/issues/91)

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -87,7 +87,8 @@ impl MouseControllable for Enigo {
     }
 
     fn mouse_move_relative(&mut self, x: i32, y: i32) {
-        mouse_event(MOUSEEVENTF_MOVE, 0, x, y);
+        let (current_x, current_y) = self.mouse_location();
+        self.mouse_move_to(current_x + x, current_y + y);
     }
 
     fn mouse_down(&mut self, button: MouseButton) {


### PR DESCRIPTION
Fixes https://github.com/enigo-rs/enigo/issues/91