### PR TITLE
Fix windows virtual keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,6 +365,8 @@ pub enum Key {
     Layout(char),
     /// raw keycode eg 0x38
     Raw(u16),
+    /// raw keycode eg 0xB3 @see https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-keybdinput#members
+    ExtendRaw(u16),
 }
 
 /// Representing an interface and a set of keyboard functions every

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -487,6 +487,7 @@ impl Enigo {
             Key::Tab => kVK_Tab,
             Key::UpArrow => kVK_UpArrow,
             Key::Raw(raw_keycode) => raw_keycode,
+            Key::ExtendRaw(raw_keycode) => raw_keycode,
             Key::Layout(c) => self.get_layoutdependent_keycode(&c.to_string()),
             Key::Super | Key::Command | Key::Windows | Key::Meta => kVK_Command,
         }

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -255,6 +255,8 @@ impl Enigo {
 
     fn is_extended_keycode(&self, key: Key) -> bool {
         match key {
+            Key::PageUp => true,
+            Key::PageDown => true,
             Key::ExtendRaw(_) => true,
             Key::Super | Key::Command | Key::Windows | Key::Meta => true,
             _ => false,


### PR DESCRIPTION
This PR should fix #67 #99

-> Key::Meta, Key::PageUp, Key:PageDown behavior has been fixed
-> Added the ability to add virtual keys like: `engio.key_click(Key::ExtendRaw(0xB3));`

I'm new to the Rust community so my code may not be good enough for pr yet 😅

**Environment**
OS: Windows 11
rustc: 1.65.0 (897e37553 2022-11-02)