### PR TITLE
Automatically detect double (and nth) clicks on macOS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,10 @@ extern crate serde;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// [`MouseButton`] represents a mouse button and is used in e.g
 /// [`MouseControllable::mouse_click`].
+
+// Warning! If there are ANY CHANGES to this enum, we
+// need to change the size of the array in the macOS implementation of the Enigo
+// struct that stores the nth click for each MouseButton
 pub enum MouseButton {
     /// Left mouse button
     Left,


### PR DESCRIPTION
This is an alternative to https://github.com/enigo-rs/enigo/pull/107 to fix https://github.com/enigo-rs/enigo/issues/82. I took the code in the other PR as inspiration and it builds, but I have not yet tested if the code does what it's supposed to. This alternative is opaque to the user and does not add any public functions.

In order to achieve this, the macOS implementation of `Enigo` stores the last time when each of the `MouseButtons` was pressed and the nth click that was. If another `mouse_down()` with the same `MouseButton` within `DOUBLE_CLICK_DELAY=500ms` is called, a double click is executed. If the time in between the clicks is too long, a single click is assumed. The 500ms are the default on Windows. I was unable to find the value for macOS. Down the road, it would probably be good to make this user configurable.