### PR TITLE
Add integration tests and run them in the CI for Linux

### DIFF
--- a/.github/actions/headless_display/action.yml
+++ b/.github/actions/headless_display/action.yml
@@ -1,0 +1,45 @@
+name: "headless_display"
+description: "Creates a virtual display so e.g Firefox can start"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install mesa3d on Windows
+      if: runner.os == 'Windows'
+      uses: ssciwr/setup-mesa-dist-win@9068b6d8a2838cde12e5d36822a1556d782e1aae
+      with:
+        version: '22.3.4'
+        deployment-choice: '5'
+    - name: Install Cygwin and xvfb on Windows (contained in xorg-server-extra)
+      if: runner.os == 'Windows'
+      uses: cygwin/cygwin-install-action@db475590d56881c6cef7b3f96f6f3dd9532ea1f4
+      with:
+        packages: xorg-server xorg-server-extra
+    - name:  Install xvfb on Linux and macOS
+      if: runner.os != 'Windows'
+      run:   |
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          sudo apt-get install xvfb -y
+          which Xvfb
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          brew install --cask xquartz
+          echo "XQUARTZ was installed"
+          sudo /opt/X11/libexec/privileged_startx || true
+          echo "privileged_startx was executed"
+          echo "/opt/X11/bin" >> $GITHUB_PATH
+        else
+          echo "This Action is only applicaple for Linux and macOS. The current runner is $RUNNER_OS, so this does nothing."
+          exit 0
+        fi
+      shell: bash
+    - name:  Set DISPLAY env variable
+      if: runner.os != 'Windows'
+      run: echo "DISPLAY=:99.0" >> $GITHUB_ENV
+      shell: bash
+    - name:  Create virtual display with Xvfb
+      if: runner.os != 'Windows'
+      run:   |
+        Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+        # Wait for xvfb to start
+        sleep 3
+      shell: bash

--- a/.github/actions/install_deps/action.yml
+++ b/.github/actions/install_deps/action.yml
@@ -8,7 +8,8 @@ runs:
       run:   |
         if [ "$RUNNER_OS" == "Linux" ]; then
           sudo apt-mark hold grub-efi-amd64-signed # TODO: Remove temporary fix
-          sudo apt-get update -q -y && sudo apt-get upgrade -y && sudo apt-get install -y libxdo-dev 
+          sudo apt-get update -q -y && sudo apt-get upgrade -y
+          sudo apt-get install -y libxdo-dev 
           echo "$RUNNER_OS"
         elif [ "$RUNNER_OS" == "Windows" ]; then
           echo "$RUNNER_OS"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,3 +60,9 @@ jobs:
         run: cargo test
       - name: Test the code with all features enabled
         run: cargo test --all-features
+
+      - name: Setup headless display for integration tests
+        uses: ./.github/actions/headless_display
+      - name: Run integration tests
+        if: runner.os == 'Linux'
+        run: cargo test --all-features -- --include-ignored --nocapture

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,11 @@ appveyor = { repository = "pythoneer/enigo-85xiy" }
 serde = { version = "1.0.102", optional = true }
 serde_derive = { version = "1.0.102", optional = true }
 
+[dev-dependencies]
+tungstenite = "0.18.0"
+url = "2.3.1"
+webbrowser = "0.8.6"
+
 [features]
 with_serde = ["serde", "serde_derive"]
 

--- a/tests/browser.rs
+++ b/tests/browser.rs
@@ -1,0 +1,42 @@
+use enigo::{Key, KeyboardControllable};
+use std::sync::mpsc::channel;
+
+mod common;
+use common::BrowserEvent;
+
+#[test]
+#[ignore]
+fn browser_events() {
+    let (tx, rs) = channel::<BrowserEvent>();
+    println!("Created channel");
+    std::thread::spawn(move || common::launch_ws_server(tx));
+    println!("WebSocket server thread was spawned");
+    std::thread::sleep(std::time::Duration::from_millis(10000)); // Wait a few seconds to make sure the browser was started
+    common::launch_browser(&rs);
+    println!("Browser was launched");
+
+    enigo::Enigo::new().key_click(Key::F11);
+    // Full screen animation
+    std::thread::sleep(std::time::Duration::from_millis(3000));
+    rs.recv_timeout(std::time::Duration::from_millis(500))
+        .unwrap(); // KeyDown("F11")
+    rs.recv_timeout(std::time::Duration::from_millis(500))
+        .unwrap(); // KeyUp("F11")
+
+    common::mouse::run(&rs);
+    println!("Mouse test successfull");
+    common::key::run(&rs);
+    println!("Keyboard test successfull");
+    println!("All tests successfull");
+}
+
+/*
+#[test]
+#[ignore]
+fn run_ws_server() {
+    let (tx, _rs) = channel::<BrowserEvent>();
+    println!("Created channel");
+    std::thread::spawn(move || common::launch_ws_server(tx));
+    std::thread::sleep(std::time::Duration::from_millis(100000)); // Sleep in order to continue running the WebSocket server in another thread
+}
+// */

--- a/tests/common/key.rs
+++ b/tests/common/key.rs
@@ -1,0 +1,33 @@
+use std::sync::mpsc::Receiver;
+
+use enigo::{Enigo, Key, KeyboardControllable};
+
+use super::BrowserEvent;
+
+pub fn run(recv: &Receiver<BrowserEvent>) {
+    press(recv, Key::F1);
+    press(recv, Key::Control);
+    press(recv, Key::Backspace);
+    // press(recv, Key::PageUp); Failing on Windows
+}
+
+fn press(recv: &Receiver<BrowserEvent>, key: Key) {
+    Enigo::new().key_down(key);
+    let ev = recv
+        .recv_timeout(std::time::Duration::from_millis(5000))
+        .unwrap();
+    if let BrowserEvent::KeyDown(pressed) = ev {
+        assert_eq!(format!("{key:?}").to_lowercase(), pressed.to_lowercase());
+    } else {
+        panic!("Event wasn't KeyDown after mouse::press. {ev:?}");
+    }
+    Enigo::new().key_up(key);
+    let ev = recv
+        .recv_timeout(std::time::Duration::from_millis(5000))
+        .unwrap();
+    if let BrowserEvent::KeyUp(pressed) = ev {
+        assert_eq!(format!("{key:?}").to_lowercase(), pressed.to_lowercase());
+    } else {
+        panic!("Event wasn't KeyUp after mouse::press. {ev:?}");
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,124 @@
+use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc::{Receiver, Sender};
+
+use tungstenite::{accept, Message};
+
+pub mod key;
+pub mod mouse;
+
+#[derive(Debug, PartialEq)]
+pub enum BrowserEvent {
+    KeyDown(String),
+    KeyUp(String),
+    MouseDown(String),
+    MouseUp(String),
+    MouseMove(((i32, i32), (i32, i32))),
+    MouseWheel((i32, i32)),
+    Open,
+    Close,
+}
+
+#[allow(clippy::similar_names)]
+fn handle_connection(stream: TcpStream, tx: &Sender<BrowserEvent>) {
+    let mut websocket = accept(stream).unwrap();
+
+    println!("Start waiting for messages");
+    loop {
+        let message = websocket.read_message().unwrap();
+        println!("Start processing message");
+
+        match message {
+            Message::Close(_) => {
+                println!("Message::Close received");
+                tx.send(BrowserEvent::Close).unwrap();
+                println!("Client disconnected");
+                return;
+            }
+            Message::Text(msg) => {
+                println!("Message::Text received");
+                println!("msg: {msg:?}");
+                let (key, data) = msg.split_once(':').unwrap();
+                let be = match key {
+                    "open" => BrowserEvent::Open,
+                    "close" => BrowserEvent::Close, // Is this needed?
+                    "keydown" => BrowserEvent::KeyDown(data.to_string()),
+                    "keyup" => BrowserEvent::KeyUp(data.to_string()),
+                    "mousedown" => BrowserEvent::MouseDown(data.to_string()),
+                    "mouseup" => BrowserEvent::MouseUp(data.to_string()),
+                    "mousemove" => {
+                        // format is relx,rely|absx,absy
+                        let (rel, abs) = data.split_once('|').unwrap();
+                        let (relx, rely) = rel.split_once(',').unwrap();
+                        let (absx, absy) = abs.split_once(',').unwrap();
+                        BrowserEvent::MouseMove((
+                            (relx.parse().unwrap(), rely.parse().unwrap()),
+                            (absx.parse().unwrap(), absy.parse().unwrap()),
+                        ))
+                    }
+                    "mousewheel" => {
+                        // format is x,y
+                        let (x, y) = data.split_once(',').unwrap();
+                        BrowserEvent::MouseWheel((x.parse().unwrap(), y.parse().unwrap()))
+                    }
+                    _ => {
+                        println!("Other text received");
+                        continue;
+                    }
+                };
+                tx.send(be).unwrap();
+            }
+            _ => {
+                println!("Other Message received");
+            }
+        }
+    }
+}
+
+pub fn launch_ws_server(tx: Sender<BrowserEvent>) {
+    let listener = TcpListener::bind("127.0.0.1:26541").unwrap();
+    println!("TcpListener was created");
+
+    match listener.accept() {
+        Ok((stream, addr)) => {
+            println!("New connection was made from {addr:?}");
+            std::thread::spawn(move || handle_connection(stream, &tx));
+        }
+        Err(e) => {
+            println!("Connection failed: {e:?}");
+        }
+    }
+}
+
+pub fn launch_browser(rs: &Receiver<BrowserEvent>) {
+    let url = &format!(
+        "file://{}/tests/index.html",
+        std::env::current_dir().unwrap().to_str().unwrap()
+    );
+    if !webbrowser::Browser::Firefox.exists() {
+        println!("Firefox is not installed");
+    }
+    if webbrowser::open_browser_with_options(
+        webbrowser::Browser::Default,
+        url,
+        webbrowser::BrowserOptions::new().with_suppress_output(false),
+    )
+    .is_err()
+    {
+        panic!("Unable to open the browser");
+    }
+    println!("Try opening test page");
+    if rs.recv_timeout(std::time::Duration::from_millis(5000)) == Ok(BrowserEvent::Open) {
+        println!("Test page was opened");
+    } else {
+        panic!("Expected Open event");
+    }
+    /*loop {
+        if rs
+            .recv_timeout(std::time::Duration::from_millis(500))
+            .is_err()
+        {
+            break;
+        }
+    }*/
+    println!("Done with launch function");
+}

--- a/tests/common/mouse.rs
+++ b/tests/common/mouse.rs
@@ -1,0 +1,85 @@
+use std::sync::mpsc::Receiver;
+
+use enigo::{Enigo, MouseControllable};
+
+use super::BrowserEvent;
+
+const ERROR: i32 = 2;
+
+pub fn run(recv: &Receiver<BrowserEvent>) {
+    println!("Move mouse");
+    set(recv, (100, 100));
+    println!("Move mouse");
+    set(recv, (200, 200));
+    println!("Rel move mouse");
+    rel(recv, (20, 20));
+    println!("Rel move mouse");
+    rel(recv, (-20, 20));
+    println!("Rel move mouse");
+    rel(recv, (20, -20));
+    println!("Rel move mouse");
+    rel(recv, (-20, -20));
+    println!("Scroll");
+    scroll(recv);
+}
+
+fn set(recv: &Receiver<BrowserEvent>, position: (i32, i32)) {
+    Enigo::new().mouse_move_to(position.0, position.1);
+    println!("Executed Enigo");
+    let ev = recv
+        .recv_timeout(std::time::Duration::from_millis(5000))
+        .unwrap();
+    println!("Done waiting");
+    if let BrowserEvent::MouseMove(pos) = ev {
+        assert!((position.0 - pos.1 .0).abs() <= ERROR);
+        assert!((position.1 - pos.1 .1).abs() <= ERROR);
+        println!("Move success");
+    } else {
+        panic!("Event wasn't MouseMove after mouse::set. {ev:?}");
+    }
+}
+
+fn rel(recv: &Receiver<BrowserEvent>, offset: (i32, i32)) {
+    Enigo::new().mouse_move_relative(offset.0, offset.1);
+    println!("Executed Enigo");
+    let ev = recv
+        .recv_timeout(std::time::Duration::from_millis(5000))
+        .unwrap();
+    println!("Done waiting");
+    if let BrowserEvent::MouseMove(pos) = ev {
+        assert!((offset.0 - pos.0 .0).abs() <= ERROR);
+        assert!((offset.1 - pos.0 .1).abs() <= ERROR);
+        println!("Rel move success");
+    } else {
+        panic!("Event wasn't MouseMove after mouse::rel. {ev:?}");
+    }
+}
+
+fn scroll(recv: &Receiver<BrowserEvent>) {
+    Enigo::new().mouse_scroll_x(1);
+    println!("Executed Enigo");
+    let ev = recv
+        .recv_timeout(std::time::Duration::from_millis(5000))
+        .unwrap();
+    println!("Done waiting");
+    if let BrowserEvent::MouseWheel(length) = ev {
+        println!("Scroll success");
+        assert!(length.0 > 0);
+        assert!(length.1 == 0);
+    } else {
+        panic!("Event wasn't MouseWheel after mouse::scroll. {ev:?}");
+    }
+    Enigo::new().mouse_scroll_y(1);
+    println!("Executed Enigo");
+    let ev = recv
+        .recv_timeout(std::time::Duration::from_millis(5000))
+        .unwrap();
+    println!("Done waiting");
+    if let BrowserEvent::MouseWheel(length) = ev {
+        println!("Scroll success");
+        assert!(length.0 == 0);
+        assert!(length.1 > 0);
+    } else {
+        panic!("Event wasn't MouseWheel after mouse::scroll. {ev:?}");
+    }
+}

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Enigo Universal Test</title>
+</head>
+
+<body>
+    <h1>Conducted tests</h1>
+    <form action="/action_page.php">
+        <input type="checkbox" id="keydown" name="keydown">
+        <label for="keydown"> keydown</label><br>
+        <input type="checkbox" id="keyup" name="keyup">
+        <label for="keyup"> keyup</label><br>
+        <input type="checkbox" id="mousedown" name="mousedown">
+        <label for="mousedown"> mousedown</label><br>
+        <input type="checkbox" id="mouseup" name="mouseup">
+        <label for="mouseup"> mouseup</label><br>
+        <input type="checkbox" id="mousemove" name="mousemove">
+        <label for="mousemove"> mousemove</label><br>
+        <input type="checkbox" id="wheel" name="wheel">
+        <label for="wheel"> wheel</label><br>
+    </form>
+
+    <p id="output1">Test did not start. Do you have JavaScript enabled?</p>
+    <script>
+        const ws = new WebSocket('ws://localhost:26541');
+        ws.addEventListener('open', (event) => {
+            console.log('connected');
+            ws.send('open:');
+            document.getElementById('output1').innerHTML = 'Test was started. Do not close the page.';
+        });
+        ws.addEventListener('close', (event) => {
+            console.log('disconnected');
+            ws.send('close:');
+            document.getElementById('output1').innerHTML = 'Test concluded. Close this page.';
+        });
+        document.addEventListener('keydown', (event) => {
+            console.log('keydown', event.key);
+            document.getElementById('keydown').checked = true;
+            ws.send('keydown:' + event.key);
+        });
+        document.addEventListener('keyup', (event) => {
+            console.log('keyup', event.key);
+            document.getElementById("keyup").checked = true;
+            ws.send('keyup:' + event.key);
+        });
+        document.addEventListener('mousedown', (event) => {
+            console.log('mousedown', event.button);
+            document.getElementById("mousedown").checked = true;
+            ws.send('mousedown:' + event.button);
+        });
+        document.addEventListener('mouseup', (event) => {
+            console.log('mouseup', event.button);
+            document.getElementById("mouseup").checked = true;
+            ws.send('mouseup:' + event.button);
+        });
+        document.addEventListener('mousemove', (event) => {
+            console.log('mousemoveX', event.movementX, event.screenX);
+            console.log('mousemoveY', event.movementY, event.screenY);
+            document.getElementById("mousemove").checked = true;
+            ws.send('mousemove:' + event.movementX + ',' + event.movementY + '|' + event.screenX + ',' + event.screenY);
+        });
+        document.addEventListener('wheel', (event) => {
+            console.log('wheelY', event.deltaY);
+            console.log('wheelX', event.deltaX);
+            document.getElementById("wheel").checked = true;
+            ws.send('mousewheel:' + event.deltaX + ',' + event.deltaY);
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
@BrettMayson had the idea to use the browser and WebSockets to run integration tests. They succeed on all platforms but only for Linux they also succeed in the CI. It is unclear why that is the case. For now the integration tests are disabled for macOS and Windows. It is still nice to have and we can re-enable them once the problem is fixed.