### PR TITLE
macOS: Simplifying the code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ windows = { version = "0.46", features = [
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
+core-foundation-sys = "0.8"
+core-foundation = "0.9"
 core-graphics = { version = "0.22", features = ["highsierra"] }
 objc = "0.2"
 unicode-segmentation = "1.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ core-foundation-sys = "0.8"
 core-foundation = "0.9"
 core-graphics = { version = "0.22", features = ["highsierra"] }
 objc = "0.2"
-unicode-segmentation = "1.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
On macOS the library panics when using `Key::Layout`. This is likely caused by input methods being used. We had a few issues (https://github.com/enigo-rs/enigo/issues/124) for it and a merged [PR](https://github.com/enigo-rs/enigo/pull/125). However the problem continues https://github.com/enigo-rs/enigo/issues/153. This is another attempt at fixing the issue.

Instead of first trying to use `TISCopyCurrentKeyboardInputSource` and then checking if it was successful, we now immediately use `TISCopyCurrentKeyboardLayoutInputSource`. This should work regardless of any input methods.

The mac I test on does not have any input methods in use, so I never saw this issue. I also cannot reproduce it. However the code continues to work for me after the changes. I am hoping for feedback from users who had issues to tell me if this PR solves them.