### PR TITLE
linux: Enable the back and forward mouse buttons

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,13 +102,13 @@ pub enum MouseButton {
     Middle,
     /// Right mouse button
     Right,
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     /// 4th mouse button. Typically performs the same function as Browser_Back
-    XButton1,
-    #[cfg(target_os = "windows")]
+    Back,
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     /// 5th mouse button. Typically performs the same function as
     /// Browser_Forward
-    XButton2,
+    Forward,
 
     /// Scroll up button. It is better to use the
     /// [MouseControllable::mouse_scroll_y] method to scroll.

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -71,6 +71,8 @@ fn mousebutton(button: MouseButton) -> c_int {
         MouseButton::ScrollDown => 5,
         MouseButton::ScrollLeft => 6,
         MouseButton::ScrollRight => 7,
+        MouseButton::Back => 8,
+        MouseButton::Forward => 9,
     }
 }
 

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -127,15 +127,15 @@ impl MouseControllable for Enigo {
                 MouseButton::Left => MOUSEEVENTF_LEFTDOWN,
                 MouseButton::Middle => MOUSEEVENTF_MIDDLEDOWN,
                 MouseButton::Right => MOUSEEVENTF_RIGHTDOWN,
-                MouseButton::XButton1 | MouseButton::XButton2 => MOUSEEVENTF_XDOWN,
+                MouseButton::Back | MouseButton::Forward => MOUSEEVENTF_XDOWN,
                 MouseButton::ScrollUp => return self.mouse_scroll_x(-1),
                 MouseButton::ScrollDown => return self.mouse_scroll_x(1),
                 MouseButton::ScrollLeft => return self.mouse_scroll_y(-1),
                 MouseButton::ScrollRight => return self.mouse_scroll_y(1),
             },
             match button {
-                MouseButton::XButton1 => 1,
-                MouseButton::XButton2 => 2,
+                MouseButton::Back => 1,
+                MouseButton::Forward => 2,
                 _ => 0,
             },
             0,
@@ -149,7 +149,7 @@ impl MouseControllable for Enigo {
                 MouseButton::Left => MOUSEEVENTF_LEFTUP,
                 MouseButton::Middle => MOUSEEVENTF_MIDDLEUP,
                 MouseButton::Right => MOUSEEVENTF_RIGHTUP,
-                MouseButton::XButton1 | MouseButton::XButton2 => MOUSEEVENTF_XUP,
+                MouseButton::Back | MouseButton::Forward => MOUSEEVENTF_XUP,
                 MouseButton::ScrollUp
                 | MouseButton::ScrollDown
                 | MouseButton::ScrollLeft
@@ -159,8 +159,8 @@ impl MouseControllable for Enigo {
                 }
             },
             match button {
-                MouseButton::XButton1 => 1,
-                MouseButton::XButton2 => 2,
+                MouseButton::Back => 1,
+                MouseButton::Forward => 2,
                 _ => 0,
             },
             0,


### PR DESCRIPTION
Linux also supports the forth and fifth mouse buttons to go back and forward so I added them