### PR TITLE
Ignore errors from `SetCursorPos`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## Changed
 - Rust: MSRV is 1.65
 - All held keys are released when Enigo is dropped
+- win: Don't panic if it was not possible to move the mouse
+- win: Don't move the mouse to a relative position if it was not possible to get the current position
 
 ## Added
 - Linux: Support X11 without `xdotools`. Use the experimental feature `x11rb` to test it

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -157,7 +157,17 @@ impl MouseControllableNext for Enigo {
     // TODO: Check if using x11rb::protocol::xproto::warp_pointer would be better
     fn send_motion_notify_event(&mut self, x: i32, y: i32, coordinate: Coordinate) {
         let (x_absolute, y_absolute) = if coordinate == Coordinate::Relative {
-            let (current_x, current_y) = self.mouse_loc();
+            // TODO: Duplicate code from the mouse_loc fn. Replace it once that function
+            // becomes fallible.
+            let mut point = POINT { x: 0, y: 0 };
+            let result = unsafe { GetCursorPos(&mut point) };
+
+            // Don't move the mouse if it wasn't possible to get the current position
+            if result.is_err() {
+                return;
+            }
+
+            let (current_x, current_y) = (point.x, point.y);
             (current_x + x, current_y + y)
         } else {
             (x, y)


### PR DESCRIPTION
Fix #177.

> Windows by default prevents the application to move the mouse if an elevated window is currently in focus (this is called UIPI). In this case SetCursorPos will return an error.

Based on my observation, `GetCursorPos` can also fail due to similar restrictions on permissions. Since `mouse_location` can not fail, using the result of that function will reset the mouse to (0,0), which is not desirable.