### PR TITLE
Added extended flag for navigation keys (Windows)

### DIFF
--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -3,11 +3,11 @@ use std::{mem::size_of, thread, time};
 use windows::Win32::Foundation::POINT;
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     MapVirtualKeyW, SendInput, VkKeyScanW, INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT,
-    KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP, KEYEVENTF_SCANCODE, KEYEVENTF_UNICODE,
-    MAP_VIRTUAL_KEY_TYPE, MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP,
-    MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP, MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP,
-    MOUSEEVENTF_WHEEL, MOUSEEVENTF_XDOWN, MOUSEEVENTF_XUP, MOUSEINPUT, MOUSE_EVENT_FLAGS,
-    VIRTUAL_KEY,
+    KEYBD_EVENT_FLAGS, KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, KEYEVENTF_SCANCODE,
+    KEYEVENTF_UNICODE, MAP_VIRTUAL_KEY_TYPE, MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN,
+    MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP, MOUSEEVENTF_RIGHTDOWN,
+    MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_WHEEL, MOUSEEVENTF_XDOWN, MOUSEEVENTF_XUP, MOUSEINPUT,
+    MOUSE_EVENT_FLAGS, VIRTUAL_KEY,
 };
 
 use windows::Win32::UI::Input::KeyboardAndMouse::{
@@ -234,13 +234,11 @@ impl KeyboardControllable for Enigo {
                 keybd_event(KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP, VIRTUAL_KEY(0), *scan);
             }
         } else {
-            keybd_event(KEYBD_EVENT_FLAGS::default(), key_to_keycode(key), 0u16);
+            let keycode = key_to_keycode(key);
+            let keyflags = get_key_flags(keycode);
+            keybd_event(keyflags, keycode, 0u16);
             thread::sleep(time::Duration::from_millis(20));
-            keybd_event(
-                KEYBD_EVENT_FLAGS::default() | KEYEVENTF_KEYUP,
-                key_to_keycode(key),
-                0u16,
-            );
+            keybd_event(keyflags | KEYEVENTF_KEYUP, keycode, 0u16);
         };
     }
 
@@ -251,7 +249,9 @@ impl KeyboardControllable for Enigo {
                 keybd_event(KEYEVENTF_SCANCODE, VIRTUAL_KEY(0), *scan);
             }
         } else {
-            keybd_event(KEYBD_EVENT_FLAGS::default(), key_to_keycode(key), 0u16);
+            let keycode = key_to_keycode(key);
+            let keyflags = get_key_flags(keycode);
+            keybd_event(keyflags, keycode, 0u16);
         };
     }
 
@@ -263,11 +263,9 @@ impl KeyboardControllable for Enigo {
                 keybd_event(KEYEVENTF_SCANCODE | KEYEVENTF_KEYUP, VIRTUAL_KEY(0), *scan);
             }
         } else {
-            keybd_event(
-                KEYBD_EVENT_FLAGS::default() | KEYEVENTF_KEYUP,
-                key_to_keycode(key),
-                0u16,
-            );
+            let keycode = key_to_keycode(key);
+            let keyflags = get_key_flags(keycode);
+            keybd_event(keyflags | KEYEVENTF_KEYUP, keycode, 0u16);
         };
     }
 }
@@ -309,6 +307,22 @@ impl Enigo {
         // to specify a layout use VkKeyScanExW and GetKeyboardLayout
         // or load one with LoadKeyboardLayoutW
         keycode_and_shiftstate
+    }
+}
+
+fn get_key_flags(vk: VIRTUAL_KEY) -> KEYBD_EVENT_FLAGS {
+    match vk {
+        // Navigation keys should be injected with the extended flag to distinguish
+        // them from the Numpad navigation keys. Otherwise, input Shift+<Navigation key>
+        // may not have the expected result and depends on whether NUMLOCK is enabled/disabled.
+        // A list of the extended keys can be found here:
+        // https://learn.microsoft.com/en-us/windows/win32/inputdev/about-keyboard-input#extended-key-flag
+        // TODO: The keys "BREAK (CTRL+PAUSE) key" and "ENTER key in the numeric keypad" are missing
+        VK_RMENU | VK_RCONTROL | VK_UP | VK_DOWN | VK_LEFT | VK_RIGHT | VK_INSERT | VK_DELETE
+        | VK_HOME | VK_END | VK_PRIOR | VK_NEXT | VK_NUMLOCK | VK_SNAPSHOT | VK_DIVIDE => {
+            KEYBD_EVENT_FLAGS::default() | KEYEVENTF_EXTENDEDKEY
+        }
+        _ => KEYBD_EVENT_FLAGS::default(),
     }
 }
 


### PR DESCRIPTION
This commit fixes a bug that occurs when simulating navigation keys in combination with Shift in Windows. 

So far, it has not been possible to select text reliably using (Ctrl) + Shift + Navigation key. The result of this action was inconsistent and dependent on the state of the numlock.  If numlock was on, Shift+RightArrow did not mark one letter, but moved the cursor. The reason for this is obvious from the sequence of keyboard messages that appear in the system queue.


The following code should cause 6 keyboard messages to appear in the Windows system message queue, but the system releases the Shift key while the navigation key is held down. If you are interested in the details, check out [The effect of numLock & The effect of Shift ](http://www.kbdedit.com/manual/high_level_numpad.html) 
```
enigo.key_down(Key::LShift);
enigo.key_click(Key::RightArrow);
enigo.key_click(Key::RightArrow);
enigo.key_up(Key::LShift);
```



**Message log from the low-level hook**
Before:
```
Keyboard event | scan: (0x)00  | virtual: LShiftKey = (0x)A0     flags INJECTED
Keyboard event | scan: (0x)22A | virtual: LShiftKey = (0x)A0     flags        KEY_RELEASED      
Keyboard event | scan: (0x)00  | virtual:     Right = (0x)27     flags INJECTED
Keyboard event | scan: (0x)00  | virtual:     Right = (0x)27     flags        KEY_RELEASED
Keyboard event | scan: (0x)2A  | virtual: LShiftKey = (0x)A0     flags INJECTED       
Keyboard event | scan: (0x)22A | virtual: LShiftKey = (0x)A0     flags        KEY_RELEASED       
Keyboard event | scan: (0x)00  | virtual:     Right = (0x)27     flags INJECTED
Keyboard event | scan: (0x)00  | virtual:     Right = (0x)27     flags        KEY_RELEASED
Keyboard event | scan: (0x)2A  | virtual: LShiftKey = (0x)A0     flags INJECTED      
Keyboard event | scan: (0x)00  | virtual: LShiftKey = (0x)A0     flags INJECTED, KEY_RELEASED
```

After: 
```
Keyboard event | scan: (0x)00 | virtual: LShiftKey = (0x)A0     flags INJECTED
Keyboard event | scan: (0x)00 | virtual:     Right = (0x)27     flags EXTENDEDKEY, INJECTED
Keyboard event | scan: (0x)00 | virtual:     Right = (0x)27     flags EXTENDEDKEY, INJECTED, KEY_RELEASED
Keyboard event | scan: (0x)00 | virtual:     Right = (0x)27     flags EXTENDEDKEY, INJECTED
Keyboard event | scan: (0x)00 | virtual:     Right = (0x)27     flags EXTENDEDKEY, INJECTED, KEY_RELEASED
Keyboard event | scan: (0x)00 | virtual: LShiftKey = (0x)A0     flags INJECTED, KEY_RELEASED
```
