### PR TITLE
linux: Fix segfault for mouse_location in release mode

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -53,13 +53,7 @@ extern "C" {
         screen: c_int,
     ) -> c_int;
 
-    fn xdo_get_mouse_location2(
-        xdo: Xdo,
-        x: *mut c_int,
-        y: *mut c_int,
-        screen: *mut c_int,
-        window: *mut Window,
-    ) -> c_int;
+    fn xdo_get_mouse_location(xdo: Xdo, x: *mut c_int, y: *mut c_int, screen: *mut c_int) -> c_int;
 }
 
 fn mousebutton(button: MouseButton) -> c_int {
@@ -184,16 +178,8 @@ impl MouseControllable for Enigo {
         let mut x = 0;
         let mut y = 0;
         let mut unused_screen_index = 0;
-        let mut unused_window_index = CURRENT_WINDOW;
-        unsafe {
-            xdo_get_mouse_location2(
-                self.xdo,
-                &mut x,
-                &mut y,
-                &mut unused_screen_index,
-                &mut unused_window_index,
-            )
-        };
+
+        unsafe { xdo_get_mouse_location(self.xdo, &mut x, &mut y, &mut unused_screen_index) };
         (x, y)
     }
 }


### PR DESCRIPTION
# Description:

This fixes #181.

In `--release` mode, calling `Enigo::mouse_location` on Linux segfaults as described in #181.

A minimal, reproducible example is as simple as:

```rust
use enigo::{Enigo, MouseControllable};

fn main() {
    let mouse = Enigo::new();
    let (x, y) = mouse.mouse_location();
    println!("Mouse is at: ({}, {})", x, y);
}
```

# Problem:

It seems as though the C-binding for `xdo_get_mouse_location2` is wrong.
https://github.com/enigo-rs/enigo/blob/8d19e12eab9d2533fedfd1089bb6abacd4b0f5b9/src/linux.rs#L56-L62

Specifically, `window` has the wrong type. It essentially gets passed a `*mut c_int` while the original C library would expect a `*mut c_ulong`.  This happens here:
https://github.com/enigo-rs/enigo/blob/8d19e12eab9d2533fedfd1089bb6abacd4b0f5b9/src/linux.rs#L183-L198

`libxdo-sys` also uses a different type: https://docs.rs/libxdo-sys/0.11.0/libxdo_sys/fn.xdo_get_mouse_location2.html 

# Solution:

Since the window index is ignored anyway, I decided to replace `xdo_get_mouse_location2` with the simpler `xdo_get_mouse_location`, which does not use a window paramter at all.

I tested this change locally, and now, `Enigo::mouse_location` works in release mode.