### PR TITLE
linux: Change the type for `Window` to `c_ulong`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,10 +56,20 @@ jobs:
       - name: Build the examples with all features enabled
         run: cargo check --examples --all-features
 
+      - name: Build the examples in release mode
+        run: cargo check --examples
+      - name: Build the examples in release mode with all features enabled
+        run: cargo check --examples --all-features
+
       - name: Test the code
         run: cargo test
       - name: Test the code with all features enabled
         run: cargo test --all-features
+
+      - name: Test the code in release mode
+        run: cargo test --release
+      - name: Test the code with all features enabled
+        run: cargo test --all-features --release
 
       - name: Setup headless display for integration tests
         if: runner.os == 'Linux' # The integration tests only work on Linux right now

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ## Added
 
 ## Fixed
+- Linux: Fixed a Segfault when running in release mode
 
 # 0.1.2
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -2,12 +2,12 @@ use libc;
 
 use crate::{Key, KeyboardControllable, MouseButton, MouseControllable};
 
-use libc::{c_char, c_int, c_void, useconds_t};
+use libc::{c_char, c_int, c_ulong, c_void, useconds_t};
 use std::{borrow::Cow, ffi::CString, ptr};
 
-const CURRENT_WINDOW: c_int = 0;
+const CURRENT_WINDOW: c_ulong = 0;
 const DEFAULT_DELAY: u64 = 12000;
-type Window = c_int;
+type Window = c_ulong;
 type Xdo = *const c_void;
 
 #[link(name = "xdo")]


### PR DESCRIPTION
- It's size should now be 32 or 64 bit, depending on your system https://github.com/enigo-rs/enigo/issues/116
- This fixes the segfault described in https://github.com/enigo-rs/enigo/issues/181

Thank you @luc4hu for your [PR](https://github.com/enigo-rs/enigo/pull/194). I mentioned you as a co-author of the commit that fixes the issue. I hope that is fine with you