### PR TITLE
Refactored the Linux code

### DIFF
--- a/.github/actions/install_deps/action.yml
+++ b/.github/actions/install_deps/action.yml
@@ -9,7 +9,7 @@ runs:
         if [ "$RUNNER_OS" == "Linux" ]; then
           sudo apt-mark hold grub-efi-amd64-signed # TODO: Remove temporary fix
           sudo apt-get update -q -y && sudo apt-get upgrade -y
-          sudo apt-get install -y libxdo-dev 
+          sudo apt-get install -y libxdo-dev libxkbcommon-dev
           echo "$RUNNER_OS"
         elif [ "$RUNNER_OS" == "Windows" ]; then
           echo "$RUNNER_OS"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ objc = "0.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
+xkbcommon = "0.6"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,0 +1,138 @@
+/// The "empty" keyboard symbol.
+// TODO: Replace it with the NO_SYMBOL from xkbcommon, once it is available
+// there
+use crate::{
+    Axis, Coordinate, Direction, Key, KeyboardControllableNext, MouseButton, MouseControllableNext,
+};
+use xkbcommon::xkb::Keysym;
+
+mod xdo;
+
+pub type ModifierBitflag = u32; // TODO: Maybe create a proper type for this
+
+#[derive(Debug)]
+pub enum ConnectionError {
+    MappingFailed(Keysym),
+    Connection(String),
+    Format(std::io::Error),
+    General(String),
+    LostConnection,
+    NoKeycode,
+    SetLayoutFailed(String),
+    Unimplemented,
+    Utf(std::string::FromUtf8Error),
+}
+
+impl std::fmt::Display for ConnectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConnectionError::MappingFailed(e) => write!(f, "Allocation failed: {e:?}"),
+            ConnectionError::Connection(e) => write!(f, "Connection: {e}"),
+            ConnectionError::Format(e) => write!(f, "Format: {e}"),
+            ConnectionError::General(e) => write!(f, "General: {e}"),
+            ConnectionError::LostConnection => write!(f, "Lost connection"),
+            ConnectionError::NoKeycode => write!(f, "No keycode mapped"),
+            ConnectionError::SetLayoutFailed(e) => write!(f, "set_layout() failed: {e}"),
+            ConnectionError::Unimplemented => write!(f, "Unimplemented"),
+            ConnectionError::Utf(e) => write!(f, "UTF: {e}"),
+        }
+    }
+}
+
+impl From<std::io::Error> for ConnectionError {
+    fn from(e: std::io::Error) -> Self {
+        ConnectionError::Format(e)
+    }
+}
+
+pub struct Enigo {
+    held: Vec<Key>, // Currently held keys
+    x11: Option<xdo::Con>,
+}
+
+impl Enigo {
+    /// Get the delay per keypress.
+    /// Default value is 12.
+    /// This is Linux-specific.
+    #[must_use]
+    pub fn delay(&self) -> u32 {
+        self.x11.as_ref().unwrap().delay()
+    }
+    /// Set the delay per keypress.
+    /// This is Linux-specific.
+    pub fn set_delay(&mut self, delay: u32) {
+        self.x11.as_mut().unwrap().set_delay(delay);
+    }
+    /// Returns a list of all currently pressed keys
+    pub fn held(&mut self) -> Vec<Key> {
+        self.held.clone()
+    }
+}
+
+impl Default for Enigo {
+    /// Create a new `Enigo` instance
+    fn default() -> Self {
+        let held = Vec::new();
+        let x11 = Some(xdo::Con::default());
+        Self { held, x11 }
+    }
+}
+
+impl MouseControllableNext for Enigo {
+    fn send_mouse_button_event(&mut self, button: MouseButton, direction: Direction, delay: u32) {
+        self.x11
+            .as_mut()
+            .unwrap()
+            .send_mouse_button_event(button, direction, delay);
+    }
+
+    // Sends a motion notify event to the X11 server via `XTest` extension
+    // TODO: Check if using x11rb::protocol::xproto::warp_pointer would be better
+    fn send_motion_notify_event(&mut self, x: i32, y: i32, coordinate: Coordinate) {
+        self.x11
+            .as_mut()
+            .unwrap()
+            .send_motion_notify_event(x, y, coordinate);
+    }
+
+    // Sends a scroll event to the X11 server via `XTest` extension
+    fn mouse_scroll_event(&mut self, length: i32, axis: Axis) {
+        self.x11.as_mut().unwrap().mouse_scroll_event(length, axis);
+    }
+
+    fn main_display(&self) -> (i32, i32) {
+        self.x11.as_ref().unwrap().main_display()
+    }
+
+    fn mouse_loc(&self) -> (i32, i32) {
+        self.x11.as_ref().unwrap().mouse_loc()
+    }
+}
+
+impl KeyboardControllableNext for Enigo {
+    /// Sends a key event to the X11 server via `XTest` extension
+    fn enter_key(&mut self, key: Key, direction: Direction) {
+        // Nothing to do
+        if key == Key::Layout('\0') {
+            return;
+        }
+        match direction {
+            Direction::Press => self.held.push(key),
+            Direction::Release => self.held.retain(|&k| k != key),
+            Direction::Click => (),
+        }
+
+        self.x11.as_mut().unwrap().enter_key(key, direction);
+    }
+}
+
+// TODO: Keep track of the held keys on Windows and Mac too and release them
+// when Enigo is dropped
+impl Drop for Enigo {
+    // Release the held keys before the connection is dropped
+    fn drop(&mut self) {
+        for &k in &self.held() {
+            self.enter_key(k, Direction::Release);
+        }
+    }
+}


### PR DESCRIPTION
 Refactored the Linux code to get ready to merge more ways to simulate input (Wayland, X11 without xdotools, ...)

Two new traits were added called `MouseControllableNext` and `KeyboardControllableNext`. They allow reducing a lot of duplicated code and might provide a basis for the future public interface of enigo.