### PR TITLE
linux: Use fast text entry where possible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,9 +414,7 @@ pub trait KeyboardControllableNext {
     /// Enter the whole text string instead of entering individual keys
     /// This is much faster if you type longer text at the cost of keyboard
     /// shortcuts not getting recognized
-    fn fast_text_entry(&mut self, _text: &str) -> Option<()> {
-        None
-    }
+    fn fast_text_entry(&mut self, _text: &str) -> Option<()>;
     /// Enter the text
     /// Use a fast method to enter the text, if it is available
     fn enter_text(&mut self, text: &str) {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -153,6 +153,15 @@ impl MouseControllableNext for Enigo {
 }
 
 impl KeyboardControllableNext for Enigo {
+    fn fast_text_entry(&mut self, text: &str) -> Option<()> {
+        #[cfg(feature = "wayland")]
+        if let Some(wayland) = self.wayland.as_mut() {
+            wayland.enter_text(text);
+        }
+        self.x11.as_mut().unwrap().enter_text(text);
+        Some(())
+    }
+
     /// Sends a key event to the X11 server via `XTest` extension
     fn enter_key(&mut self, key: Key, direction: Direction) {
         // Nothing to do

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -140,6 +140,11 @@ impl Bind<Keycode> for CompositorConnection {
 }
 
 impl KeyboardControllableNext for Con {
+    fn fast_text_entry(&mut self, _text: &str) -> Option<()> {
+        // TODO: Add fast method
+        // xdotools can do it, so it is possible
+        None
+    }
     /// Try to enter the key
     fn enter_key(&mut self, key: Key, direction: Direction) {
         self.keymap.make_room(&());

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -324,6 +324,9 @@ impl MouseControllableNext for Enigo {
 
 // https://stackoverflow.com/questions/1918841/how-to-convert-ascii-character-to-cgkeycode
 impl KeyboardControllableNext for Enigo {
+    fn fast_text_entry(&mut self, _text: &str) -> Option<()> {
+        None
+    }
     /// Enter the text
     /// Use a fast method to enter the text, if it is available
     fn enter_text(&mut self, text: &str) {

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -189,6 +189,10 @@ impl MouseControllableNext for Enigo {
 }
 
 impl KeyboardControllableNext for Enigo {
+    fn fast_text_entry(&mut self, _text: &str) -> Option<()> {
+        None
+    }
+
     /// Enter the whole text string instead of entering individual keys
     /// This is much faster if you type longer text at the cost of keyboard
     /// shortcuts not getting recognized


### PR DESCRIPTION
The `input_method` protocol was previously not used but each character was entered individually. This is much slower than entering the whole string at once.

This somehow broke entering the Control key right after the input_method