### PR TITLE
win, linux: Handle special chars so that the correct key is entered

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 ## Fixed
 - macOS: Add info how much a mouse was moved relative to the last position
 - macOS: A mouse drag with the right key is now possible too
-- win: `key_sequence()` and  `key_click(Key::Layout())` can properly enter new lines and tabs
+- win, linux: `key_sequence()` and  `key_click(Key::Layout())` can properly enter new lines and tabs
 
 # 0.1.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,11 @@
 ## Added
 - Linux: Support X11 without `xdotools`. Use the experimental feature `x11rb` to test it
 - Linux: Partial support for Wayland was added. Use the experimental feature `wayland` to test it. Only the virtual_keyboard and input_method protocol can be used. This is not going to work on GNOME, but should work for example with phosh
+
 ## Fixed
 - macOS: Add info how much a mouse was moved relative to the last position
 - macOS: A mouse drag with the right key is now possible too
+- win: `key_sequence()` and  `key_click(Key::Layout())` can properly enter new lines and tabs
 
 # 0.1.3
 

--- a/src/linux/keymap.rs
+++ b/src/linux/keymap.rs
@@ -80,7 +80,9 @@ where
         match key {
             Key::Layout(c) => match c {
                 '\n' => Keysym::Return,
+                '\r' => NO_SYMBOL, // TODO: What is the correct key to type here?
                 '\t' => Keysym::Tab,
+                '\0' => NO_SYMBOL,
                 _ => {
                     // TODO: Replace with Keysym.from_char(ch: char)
                     let hex: u32 = c.into();

--- a/src/linux/keymap.rs
+++ b/src/linux/keymap.rs
@@ -76,6 +76,7 @@ where
     /// Converts a Key to a Keysym
     #[allow(clippy::too_many_lines)]
     pub fn key_to_keysym(key: Key) -> Keysym {
+        #[allow(clippy::match_same_arms)]
         match key {
             Key::Layout(c) => match c {
                 '\n' => Keysym::Return,

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -205,6 +205,15 @@ impl KeyboardControllableNext for Enigo {
         let mut buffer = [0; 2];
 
         for c in text.chars() {
+            // Handle special characters seperately
+            match c {
+                '\n' => return self.enter_key(Key::Return, Direction::Click),
+                '\r' => { // TODO: What is the correct key to type here?
+                }
+                '\t' => return self.enter_key(Key::Tab, Direction::Click),
+                '\0' => return,
+                _ => (),
+            }
             // Windows uses uft-16 encoding. We need to check
             // for variable length characters. As such some
             // characters can be 32 bit long and those are
@@ -233,10 +242,6 @@ impl KeyboardControllableNext for Enigo {
 
     /// Sends a key event to the X11 server via `XTest` extension
     fn enter_key(&mut self, key: Key, direction: Direction) {
-        // Nothing to do
-        if key == Key::Layout('\0') {
-            return;
-        }
         match direction {
             Direction::Press => self.held.push(key),
             Direction::Release => self.held.retain(|&k| k != key),
@@ -244,6 +249,15 @@ impl KeyboardControllableNext for Enigo {
         }
 
         if let Key::Layout(c) = key {
+            // Handle special characters seperately
+            match c {
+                '\n' => return self.enter_key(Key::Return, direction),
+                '\r' => { // TODO: What is the correct key to type here?
+                }
+                '\t' => return self.enter_key(Key::Tab, direction),
+                '\0' => return,
+                _ => (),
+            }
             let scancodes = self.get_scancode(c);
             if direction == Direction::Click || direction == Direction::Press {
                 for scan in &scancodes {


### PR DESCRIPTION
The following code used to not work correctly:

```Rust
use enigo::{Enigo, Key, KeyboardControllable};
use std::thread;
use std::time::Duration;

fn main() {
    thread::sleep(Duration::from_secs(2));
    let mut enigo = Enigo::new();

    // write text
    enigo.key_sequence(
        "Hello World! here 
    is a lot of \ntext\t ❤️",
    );

    enigo.key_click(Key::Layout('\n'));
```

The `\n` and `\t` chars need special handling. This PR fixes the behavior on all platforms EXCEPT for Mac

Fixes https://github.com/enigo-rs/enigo/issues/199 and https://github.com/enigo-rs/enigo/issues/175