### PR TITLE
add mouse option to DSL

### DIFF
--- a/src/dsl.rs
+++ b/src/dsl.rs
@@ -200,7 +200,6 @@ fn tokenize(input: &str) -> Result<Vec<Token>, ParseError> {
                     } else {
                         &tag[1..]
                     };
-                    println!("Tag: {}", &tag);
 
                     if key == "UNICODE" {
                         unicode = match action {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,6 +380,33 @@ impl Enigo {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Type the string parsed with DSL.
+    ///
+    /// Typing {+SHIFT}hello{-SHIFT} becomes HELLO.
+    /// Please have a look at the [dsl] module for more information.
+    pub fn mouse_and_key_sequence_parse(&mut self, sequence: &str)
+    where
+        Self: Sized,
+    {
+        self.mouse_and_key_sequence_parse_try(sequence)
+            .expect("Could not parse sequence");
+    }
+
+    /// Same as [`Enigo::key_sequence_parse`] except returns any
+    /// errors
+    ///  # Errors
+    ///
+    /// Returns a [`dsl::ParseError`] if the sequence cannot be parsed
+    pub fn mouse_and_key_sequence_parse_try(
+        &mut self,
+        sequence: &str,
+    ) -> Result<(), dsl::ParseError>
+    where
+        Self: Sized,
+    {
+        dsl::eval_mouse(self, sequence)
+    }
 }
 
 impl KeyboardControllable for Enigo {}


### PR DESCRIPTION
 Syntax: {+MOUSE}x:y{-MOUSE}. This feature only works if DSL is called with MouseControllable which is only required in the eval_mouse method. This method is access through the enigio class via the mouse_and_key_sequence_parse_try method.