### PR TITLE
Macos improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 - Linux: Partial support for Wayland was added. Use the experimental feature `wayland` to test it. Only the virtual_keyboard and input_method protocol can be used. This is not going to work on GNOME, but should work for example with phosh
 ## Fixed
 - macOS: Add info how much a mouse was moved relative to the last position
+- macOS: A mouse drag with the right key is now possible too
 
 # 0.1.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Linux: Support X11 without `xdotools`. Use the experimental feature `x11rb` to test it
 - Linux: Partial support for Wayland was added. Use the experimental feature `wayland` to test it. Only the virtual_keyboard and input_method protocol can be used. This is not going to work on GNOME, but should work for example with phosh
 ## Fixed
+- macOS: Add info how much a mouse was moved relative to the last position
 
 # 0.1.3
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,6 +418,9 @@ pub trait KeyboardControllableNext {
     /// Enter the text
     /// Use a fast method to enter the text, if it is available
     fn enter_text(&mut self, text: &str) {
+        if text.is_empty() {
+            return; // Nothing to simulate.
+        }
         // Fall back to entering single keys if no fast text entry is available
         if self.fast_text_entry(text).is_none() {
             for c in text.chars() {

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -273,13 +273,14 @@ impl MouseControllableNext for Enigo {
             Coordinate::Relative => ((current_x + x, current_y + y), (x, y)),
         };
 
-        let event_type = if pressed & 1 > 0 {
-            CGEventType::LeftMouseDragged
-        } else if pressed & 2 > 0 {
-            CGEventType::RightMouseDragged
-        } else {
-            CGEventType::MouseMoved
-        };
+        let (event_type, mouse_button) =
+            if pressed & 1 > 0 {
+                (CGEventType::LeftMouseDragged, CGMouseButton::Left)
+            } else if pressed & 2 > 0 {
+                (CGEventType::RightMouseDragged, CGMouseButton::Right)
+            } else {
+                (CGEventType::MouseMoved, CGMouseButton::Left) // The mouse button here is ignored so it can be anything
+            };
 
         let dest = CGPoint::new(absolute.0 as f64, absolute.1 as f64);
         let event =

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -342,6 +342,9 @@ impl KeyboardControllableNext for Enigo {
     /// Enter the text
     /// Use a fast method to enter the text, if it is available
     fn enter_text(&mut self, text: &str) {
+        if text.is_empty() {
+            return; // Nothing to simulate.
+        }
         // NOTE(dustin): This is a fix for issue https://github.com/enigo-rs/enigo/issues/68
         // The CGEventKeyboardSetUnicodeString function (used inside of
         // event.set_string(cluster)) truncates strings down to 20 characters

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -199,6 +199,9 @@ impl KeyboardControllableNext for Enigo {
     /// This is much faster if you type longer text at the cost of keyboard
     /// shortcuts not getting recognized
     fn enter_text(&mut self, text: &str) {
+        if text.is_empty() {
+            return; // Nothing to simulate.
+        }
         let mut buffer = [0; 2];
 
         for c in text.chars() {


### PR DESCRIPTION
MouseMove events on macOS can contain information about how much the mouse was moved relative to it's last location. Some applications only use that so this information was added to each event.

Previously there was also a bug that prevented a mouse drag with the right mouse button.

If it is attempted to enter an empty string, nothing will be done