### PR TITLE
CI: Run cargo fmt only on Rust nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Check the code format
+        if: ${{ matrix.rust }} == 'nightly' # Ignore all format differences if they are not on nightly
         run: cargo fmt -- --check
 
       - name: Check clippy lints


### PR DESCRIPTION
Sometimes the Rust versions can format things differently so it would be impossible to satisfy the old versions and nightly at the same time