### PR TITLE
win: Got rid of all sleeps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 - macOS: A mouse drag with the right key is now possible too
 - win, linux: `key_sequence()` and  `key_click(Key::Layout())` can properly enter new lines and tabs
 - linux: You can enter `Key::ScrollLock` now
+- win: No more sleeps! Simulating input is done in 1 ms instead of 40+ ms. This is most obvious when entering long strings
 
 # 0.1.3
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,8 +562,6 @@ impl Error for NewConError {}
 #[allow(dead_code)] // It is not dead code on other platforms
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EnigoSettings {
-    /// Sleep delay on Windows
-    win_delay: u32,
     /// Sleep delay on macOS
     mac_delay: u32,
     /// Sleep delay on Linux X11
@@ -580,7 +578,6 @@ pub struct EnigoSettings {
 impl Default for EnigoSettings {
     fn default() -> Self {
         Self {
-            win_delay: 20,
             mac_delay: 20,
             linux_delay: 12,
             x11_display: None,


### PR DESCRIPTION
This will finally get rid of all sleeps in the code. This was possible by using an array of INPUTs in the SendInput function. Apparently this was the reason why there needed to be sleeps in the code for all input to be registered.