### PR TITLE
wayland: Use the wayland_display from the EnigoSettings to establish a connection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,16 +563,16 @@ impl Error for NewConError {}
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EnigoSettings {
     /// Sleep delay on macOS
-    mac_delay: u32,
+    pub mac_delay: u32,
     /// Sleep delay on Linux X11
-    linux_delay: u32,
+    pub linux_delay: u32,
     /// Display name to connect to when using Linux X11
-    x11_display: Option<String>,
+    pub x11_display: Option<String>,
     /// Display name to connect to when using Linux Wayland
-    wayland_display: Option<String>,
+    pub wayland_display: Option<String>,
     /// Set this to true if you want all held keys to get released when Enigo
     /// gets dropped
-    release_keys_when_dropped: bool,
+    pub release_keys_when_dropped: bool,
 }
 
 impl Default for EnigoSettings {


### PR DESCRIPTION
Previously the wayland_display field of the EnigoSettings struct was not used. It is now implemented. You can now provide a string to be used as the display name on Wayland as well.

```Rust
use enigo::{Enigo, EnigoSettings, KeyboardControllable};
use std::thread;
use std::time::Duration;

fn main() {
    thread::sleep(Duration::from_secs(2));
    let mut enigo = Enigo::new(&EnigoSettings {
        wayland_display: Some("wayland-0".to_string()),
        ..Default::default()
    })
    .unwrap();

    // write text
    enigo.key_sequence("Hello World! ❤️");
}
```