### PR TITLE
X11rb fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - Linux: Partial support for Wayland was added. Use the experimental feature `wayland` to test it. Only the virtual_keyboard and input_method protocol can be used. This is not going to work on GNOME, but should work for example with phosh
 - win: Use DirectInput in addition to the SetCursorPos function in order to support DirectX
 - All: You can now chose how long the delay between keypresses should be on each platform and change it during the runtime
+- All: You can now use a logger to investigate errors
 
 ## Fixed
 - macOS: Add info how much a mouse was moved relative to the last position

--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -572,12 +572,12 @@ pub enum Key {
 
 #[cfg(target_os = "linux")]
 /// Converts a Key to a Keysym
-impl TryFrom<Key> for xkbcommon::xkb::Keysym {
+impl TryFrom<Key> for xkeysym::Keysym {
     type Error = &'static str;
 
     #[allow(clippy::too_many_lines)]
     fn try_from(key: Key) -> Result<Self, &'static str> {
-        use xkbcommon::xkb::Keysym;
+        use xkeysym::Keysym;
 
         #[allow(clippy::match_same_arms)]
         Ok(match key {

--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -676,3 +676,79 @@ impl TryFrom<Key> for xkbcommon::xkb::Keysym {
         })
     }
 }
+
+#[cfg(target_os = "linux")]
+#[cfg(any(feature = "wayland", feature = "x11rb"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Modifier {
+    Shift,
+    Lock,
+    Control,
+    Mod1,
+    Mod2,
+    Mod3,
+    Mod4,
+    Mod5,
+}
+
+#[cfg(target_os = "linux")]
+#[cfg(any(feature = "wayland", feature = "x11rb"))]
+impl Modifier {
+    /// Returns the bitflag of the modifier that is usually associated with it
+    /// on Linux
+    #[must_use]
+    pub fn bitflag(&self) -> ModifierBitflag {
+        match self {
+            Self::Shift => 0x1,
+            Self::Lock => 0x2,
+            Self::Control => 0x4,
+            Self::Mod1 => 0x8,
+            Self::Mod2 => 0x10,
+            Self::Mod3 => 0x20,
+            Self::Mod4 => 0x40,
+            Self::Mod5 => 0x80,
+        }
+    }
+
+    /// Returns the number of the modifier that is usually associated with it
+    /// on Linux
+    #[must_use]
+    pub fn no(&self) -> usize {
+        match self {
+            Self::Shift => 0,
+            Self::Lock => 1,
+            Self::Control => 2,
+            Self::Mod1 => 3,
+            Self::Mod2 => 4,
+            Self::Mod3 => 5,
+            Self::Mod4 => 6,
+            Self::Mod5 => 7,
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[cfg(any(feature = "wayland", feature = "x11rb"))]
+/// Converts a Key to a modifier
+impl TryFrom<Key> for Modifier {
+    type Error = &'static str;
+
+    fn try_from(key: Key) -> Result<Self, &'static str> {
+        match key {
+            Key::Shift | Key::LShift | Key::RShift => Ok(Self::Shift),
+            Key::CapsLock => Ok(Self::Lock),
+            Key::Control | Key::LControl | Key::RControl => Ok(Self::Control),
+            Key::Alt | Key::Option => Ok(Self::Mod1),
+            Key::Numlock => Ok(Self::Mod2),
+            // The Mod3 modifier is usually unmapped
+            // Key::Mod3 => Ok(Self::Mod3),
+            Key::Command | Key::Super | Key::Windows | Key::Meta => Ok(Self::Mod4),
+            Key::ModeChange => Ok(Self::Mod5),
+            _ => Err("not a modifier key"),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[cfg(any(feature = "wayland", feature = "x11rb"))]
+pub(crate) type ModifierBitflag = u32; // TODO: Maybe create a proper type for this

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -619,12 +619,12 @@ impl Display for InputError {
             InputError::Mapping(e) => format!("error when mapping keycode to keysym: ({e})"),
             InputError::Unmapping(e) => format!("error when unmapping keysym: ({e})"),
             InputError::NoEmptyKeycodes => {
-                format!("there were no empty keycodes that could be used")
+                "there were no empty keycodes that could be used".to_string()
             }
             InputError::Simulate(e) => format!("simulating input failed: ({e})"),
             InputError::InvalidInput(e) => format!("you tried to simulate invalid input: ({e})"),
         };
-        write!(f, "{}", string)
+        write!(f, "{string}")
     }
 }
 
@@ -645,14 +645,15 @@ impl Display for NewConError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let string = match self {
             NewConError::EstablishCon(e) => format!("no connection could be established: ({e})"),
-            NewConError::Reply => format!(
+            NewConError::Reply => {
                 "there was an error with the reply from the display server. this should not happen"
-            ),
+                    .to_string()
+            }
             NewConError::NoEmptyKeycodes => {
-                format!("there were no empty keycodes that could be used")
+                "there were no empty keycodes that could be used".to_string()
             }
         };
-        write!(f, "{}", string)
+        write!(f, "{string}")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,7 +615,16 @@ pub enum InputError {
 
 impl Display for InputError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "error establishing X11 connection with x11rb")
+        let string = match self {
+            InputError::Mapping(e) => format!("error when mapping keycode to keysym: ({e})"),
+            InputError::Unmapping(e) => format!("error when unmapping keysym: ({e})"),
+            InputError::NoEmptyKeycodes => {
+                format!("there were no empty keycodes that could be used")
+            }
+            InputError::Simulate(e) => format!("simulating input failed: ({e})"),
+            InputError::InvalidInput(e) => format!("you tried to simulate invalid input: ({e})"),
+        };
+        write!(f, "{}", string)
     }
 }
 
@@ -634,7 +643,16 @@ pub enum NewConError {
 
 impl Display for NewConError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "error establishing X11 connection with x11rb")
+        let string = match self {
+            NewConError::EstablishCon(e) => format!("no connection could be established: ({e})"),
+            NewConError::Reply => format!(
+                "there was an error with the reply from the display server. this should not happen"
+            ),
+            NewConError::NoEmptyKeycodes => {
+                format!("there were no empty keycodes that could be used")
+            }
+        };
+        write!(f, "{}", string)
     }
 }
 

--- a/src/linux/keymap.rs
+++ b/src/linux/keymap.rs
@@ -5,10 +5,9 @@ use std::fmt::Display;
 use log::{debug, trace};
 pub(super) use xkbcommon::xkb::Keysym;
 
-use crate::{Direction, InputError, InputResult, Key};
-
 #[cfg(feature = "wayland")]
-pub(super) type ModifierBitflag = u32; // TODO: Maybe create a proper type for this
+use crate::keycodes::ModifierBitflag;
+use crate::{Direction, InputError, InputResult, Key};
 
 /// The "empty" keyboard symbol.
 // TODO: Replace it with the NO_SYMBOL from xkbcommon, once it is available
@@ -199,10 +198,10 @@ where
                 .try_into()
                 .unwrap_or(u32::MAX);
             self.pending_delays = self.delay.saturating_sub(elapsed_ms);
-            debug!("delay needed");
+            trace!("delay needed");
             self.last_keys.clear();
         } else {
-            debug!("no delay needed");
+            trace!("no delay needed");
             self.pending_delays = 1;
         }
         self.last_keys.push(keycode);

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,4 +1,4 @@
-use log::{debug, error, warn};
+use log::{debug, error, trace, warn};
 
 use crate::{
     Axis, Coordinate, Direction, EnigoSettings, InputError, InputResult, Key,
@@ -146,20 +146,20 @@ impl MouseControllableNext for Enigo {
         let mut success = false;
         #[cfg(feature = "wayland")]
         if let Some(con) = self.wayland.as_mut() {
-            debug!("try sending button event via wayland");
+            trace!("try sending button event via wayland");
             con.send_mouse_button_event(button, direction)?;
-            debug!("successfully sent button event via wayland");
+            debug!("sent button event via wayland");
             success = true;
         }
         #[cfg(any(feature = "x11rb", feature = "xdo"))]
         if let Some(con) = self.x11.as_mut() {
-            debug!("try sending button event via x11");
+            trace!("try sending button event via x11");
             con.send_mouse_button_event(button, direction)?;
-            debug!("successfully sent button event via x11");
+            debug!("sent button event via x11");
             success = true;
         }
         if success {
-            debug!("successfully sent button event");
+            debug!("sent button event");
             Ok(())
         } else {
             Err(InputError::Simulate("No protocol to enter the result"))
@@ -176,20 +176,20 @@ impl MouseControllableNext for Enigo {
         let mut success = false;
         #[cfg(feature = "wayland")]
         if let Some(con) = self.wayland.as_mut() {
-            debug!("try moving the mouse via wayland");
+            trace!("try moving the mouse via wayland");
             con.send_motion_notify_event(x, y, coordinate)?;
-            debug!("successfully moved the mouse via wayland");
+            debug!("moved the mouse via wayland");
             success = true;
         }
         #[cfg(any(feature = "x11rb", feature = "xdo"))]
         if let Some(con) = self.x11.as_mut() {
-            debug!("try moving the mouse via x11");
+            trace!("try moving the mouse via x11");
             con.send_motion_notify_event(x, y, coordinate)?;
-            debug!("successfully moved the mouse via x11");
+            debug!("moved the mouse via x11");
             success = true;
         }
         if success {
-            debug!("successfully moved the mouse");
+            debug!("moved the mouse");
             Ok(())
         } else {
             Err(InputError::Simulate("No protocol to enter the result"))
@@ -201,20 +201,20 @@ impl MouseControllableNext for Enigo {
         let mut success = false;
         #[cfg(feature = "wayland")]
         if let Some(con) = self.wayland.as_mut() {
-            debug!("try scrolling via wayland");
+            trace!("try scrolling via wayland");
             con.mouse_scroll_event(length, axis)?;
-            debug!("successfully scrolled via wayland");
+            debug!("scrolled via wayland");
             success = true;
         }
         #[cfg(any(feature = "x11rb", feature = "xdo"))]
         if let Some(con) = self.x11.as_mut() {
-            debug!("try scrolling via x11");
+            trace!("try scrolling via x11");
             con.mouse_scroll_event(length, axis)?;
-            debug!("successfully scrolled via x11");
+            debug!("scrolled via x11");
             success = true;
         }
         if success {
-            debug!("successfully scrolled");
+            debug!("scrolled");
             Ok(())
         } else {
             Err(InputError::Simulate("No protocol to enter the result"))
@@ -225,12 +225,12 @@ impl MouseControllableNext for Enigo {
         debug!("\x1b[93mmain_display()\x1b[0m");
         #[cfg(feature = "wayland")]
         if let Some(con) = self.wayland.as_ref() {
-            debug!("try getting the dimensions of the display via wayland");
+            trace!("try getting the dimensions of the display via wayland");
             return con.main_display();
         }
         #[cfg(any(feature = "x11rb", feature = "xdo"))]
         if let Some(con) = self.x11.as_ref() {
-            debug!("try getting the dimensions of the display via x11");
+            trace!("try getting the dimensions of the display via x11");
             return con.main_display();
         }
         Err(InputError::Simulate("No protocol to enter the result"))
@@ -240,12 +240,12 @@ impl MouseControllableNext for Enigo {
         debug!("\x1b[93mmouse_loc()\x1b[0m");
         #[cfg(feature = "wayland")]
         if let Some(con) = self.wayland.as_ref() {
-            debug!("try getting the mouse location via wayland");
+            trace!("try getting the mouse location via wayland");
             return con.mouse_loc();
         }
         #[cfg(any(feature = "x11rb", feature = "xdo"))]
         if let Some(con) = self.x11.as_ref() {
-            debug!("try getting the mouse location via x11");
+            trace!("try getting the mouse location via x11");
             return con.mouse_loc();
         }
         Err(InputError::Simulate("No protocol to enter the result"))
@@ -257,15 +257,15 @@ impl KeyboardControllableNext for Enigo {
         debug!("\x1b[93mfast_text_entry(text: {text})\x1b[0m");
         #[cfg(feature = "wayland")]
         if let Some(con) = self.wayland.as_mut() {
-            debug!("try entering text fast via wayland");
+            trace!("try entering text fast via wayland");
             con.enter_text(text)?;
         }
         #[cfg(any(feature = "x11rb", feature = "xdo"))]
         if let Some(con) = self.x11.as_mut() {
-            debug!("try entering text fast via x11");
+            trace!("try entering text fast via x11");
             con.enter_text(text)?;
         }
-        debug!("successfully entered text fast");
+        debug!("entered the text fast");
         Ok(Some(()))
     }
 
@@ -279,15 +279,15 @@ impl KeyboardControllableNext for Enigo {
 
         #[cfg(feature = "wayland")]
         if let Some(con) = self.wayland.as_mut() {
-            debug!("try entering the key via wayland");
+            trace!("try entering the key via wayland");
             con.enter_key(key, direction)?;
-            debug!("successfully entered the key via wayland");
+            debug!("entered the key via wayland");
         }
         #[cfg(any(feature = "x11rb", feature = "xdo"))]
         if let Some(con) = self.x11.as_mut() {
-            debug!("try entering the key via x11");
+            trace!("try entering the key via x11");
             con.enter_key(key, direction)?;
-            debug!("successfully entered the key via x11");
+            debug!("entered the key via x11");
         }
 
         match direction {
@@ -302,7 +302,7 @@ impl KeyboardControllableNext for Enigo {
             Direction::Click => (),
         }
 
-        debug!("successfully entered the key");
+        debug!("entered the key");
         Ok(())
     }
 }

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -62,7 +62,7 @@ impl Enigo {
                 Some(con)
             }
             Err(e) => {
-                warn!("failed to establish wayland connection: {e}");
+                warn!("{e}");
                 None
             }
         };

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -276,17 +276,6 @@ impl KeyboardControllableNext for Enigo {
             debug!("entering the null byte is a noop");
             return Ok(());
         }
-        match direction {
-            Direction::Press => {
-                debug!("added the key {key:?} to the held keys");
-                self.held.push(key);
-            }
-            Direction::Release => {
-                debug!("removed the key {key:?} from the held keys");
-                self.held.retain(|&k| k != key);
-            }
-            Direction::Click => (),
-        }
 
         #[cfg(feature = "wayland")]
         if let Some(con) = self.wayland.as_mut() {
@@ -300,6 +289,19 @@ impl KeyboardControllableNext for Enigo {
             con.enter_key(key, direction)?;
             debug!("successfully entered the key via x11");
         }
+
+        match direction {
+            Direction::Press => {
+                debug!("added the key {key:?} to the held keys");
+                self.held.push(key);
+            }
+            Direction::Release => {
+                debug!("removed the key {key:?} from the held keys");
+                self.held.retain(|&k| k != key);
+            }
+            Direction::Click => (),
+        }
+
         debug!("successfully entered the key");
         Ok(())
     }

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -566,9 +566,6 @@ impl KeyboardControllableNext for Con {
     }
 
     fn enter_key(&mut self, key: Key, direction: Direction) -> InputResult<()> {
-        if self.keymap.make_room(&())? {
-            self.apply_keymap()?;
-        }
         let keycode = self.keymap.key_to_keycode(&(), key)?;
 
         // Apply the new keymap if there were any changes

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -6,7 +6,7 @@ use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::time::Instant;
 
-use log::{debug, error, warn};
+use log::{debug, error, trace, warn};
 use wayland_client::{
     protocol::{wl_pointer, wl_registry, wl_seat},
     Connection, Dispatch, EventQueue, QueueHandle,
@@ -385,7 +385,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                     state.kde_input = Some(kde_input);
                 }
                 s => {
-                    debug!("i: {}", s);
+                    trace!("i: {}", s);
                 }
             }
         }

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -590,6 +590,11 @@ impl KeyboardControllableNext for Con {
         } else {
             self.send_key_event(keycode, direction)?;
         }
+
+        // Let the keymap know that the key was held/no longer held
+        // This is important to avoid unmapping held keys
+        self.keymap.enter_key(keycode, direction);
+
         Ok(())
     }
 }

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -145,6 +145,12 @@ impl Con {
         }
         let keymap = KeyMap::new(8, 255, unused_keycodes);
 
+        if virtual_keyboard.is_none() && input_method.is_none() && virtual_pointer.is_none() {
+            return Err(NewConError::EstablishCon(
+                "no protocol available to simulate input",
+            ));
+        }
+
         Ok(Self {
             keymap,
             event_queue,

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -143,7 +143,10 @@ impl Con {
         for n in 8..=255 {
             unused_keycodes.push_back(n as Keycode);
         }
-        let keymap = KeyMap::new(8, 255, unused_keycodes);
+
+        // TODO: Double check this and adjust it
+        let (keysyms_per_keycode, keysyms) = (0, vec![]);
+        let keymap = KeyMap::new(8, 255, unused_keycodes, keysyms_per_keycode, keysyms);
 
         if virtual_keyboard.is_none() && input_method.is_none() && virtual_pointer.is_none() {
             return Err(NewConError::EstablishCon(

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -176,7 +176,7 @@ impl Bind<Keycode> for CompositorConnection {
 
 impl KeyboardControllableNext for Con {
     fn fast_text_entry(&mut self, _text: &str) -> InputResult<Option<()>> {
-        warn!("fast text entry is not yet implemented with xdo");
+        warn!("fast text entry is not yet implemented with x11rb");
         // TODO: Add fast method
         // xdotools can do it, so it is possible
         Ok(None)

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -118,15 +118,21 @@ impl Con {
             .reply()?;
 
         // Split the mapping into the chunks of keysyms that are mapped to each keycode
+        trace!("initial keymap:");
         let keysyms = keysyms.chunks(keysyms_per_keycode as usize);
-        debug!("unused keycodes:");
         for (syms, kc) in keysyms.zip(keycode_min..=keycode_max) {
             // Check if the keycode is unused
+
+            if log::log_enabled!(log::Level::Trace) {
+                let syms_name: Vec<Keysym> = syms.into_iter().map(|&s| Keysym::from(s)).collect();
+                trace!("{kc}:  {syms_name:?}");
+            }
+
             if syms.iter().all(|&s| s == NO_SYMBOL.raw()) {
-                debug!("{}", kc);
                 unused_keycodes.push_back(kc);
             }
         }
+        debug!("unused keycodes: {unused_keycodes:?}");
         Ok(unused_keycodes)
     }
     /// Find the keycodes that must be used for the modifiers
@@ -139,7 +145,8 @@ impl Con {
             keycodes: modifiers,
             ..
         } = modifier_reply;
-        trace!("the keycodes associated with the modifiers are {modifiers:?}");
+        trace!("keycodes per modifier: {keycodes_per_modifier:?}");
+        trace!("the keycodes associated with the modifiers are:\n{modifiers:?}");
 
         debug!("modifier mapping:");
         let mut modifier_keycodes = vec![0; 8];

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -183,12 +183,10 @@ impl KeyboardControllableNext for Con {
     }
 
     fn enter_key(&mut self, key: Key, direction: Direction) -> InputResult<()> {
-        self.keymap.make_room(&())?;
         let keycode = self.keymap.key_to_keycode(&self.connection, key)?;
-        self.keymap.update_delays(keycode);
 
         let detail = keycode;
-        let time = self.keymap.pending_delays;
+        let time = self.keymap.pending_delays();
         let root = self.screen.root;
         let root_x = 0;
         let root_y = 0;
@@ -217,7 +215,7 @@ impl KeyboardControllableNext for Con {
 
         // TODO: Check if we need to update the delays again
         // self.keymap.update_delays(keycode);
-        // let time = self.keymap.pending_delays;
+        // let time = self.keymap.pending_delays();
 
         if direction == Direction::Release || direction == Direction::Click {
             self.connection
@@ -241,8 +239,6 @@ impl KeyboardControllableNext for Con {
                 error!("{e}");
                 InputError::Simulate("error when syncing with X server using x11rb after the keyboard mapping was changed: {e:?}")
             })?;
-
-        self.keymap.last_event_before_delays = std::time::Instant::now();
 
         // Let the keymap know that the key was held/no longer held
         // This is important to avoid unmapping held keys

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -195,8 +195,8 @@ impl KeyboardControllableNext for Con {
         let deviceid = self.device_id(DeviceUse::IS_X_KEYBOARD)?;
 
         debug!(
-            "xtest_fake_input with keycode {}, deviceid {}",
-            detail, deviceid
+            "xtest_fake_input with keycode {}, deviceid {}, delay {}",
+            detail, deviceid, time
         );
         if direction == Direction::Press || direction == Direction::Click {
             self.connection
@@ -271,8 +271,8 @@ impl MouseControllableNext for Con {
         let deviceid = self.device_id(DeviceUse::IS_X_POINTER)?;
 
         debug!(
-            "xtest_fake_input with button {}, deviceid {}",
-            detail, deviceid
+            "xtest_fake_input with button {}, deviceid {}, delay {}",
+            detail, deviceid, time
         );
         if direction == Direction::Press || direction == Direction::Click {
             self.connection
@@ -347,8 +347,8 @@ impl MouseControllableNext for Con {
         let deviceid = self.device_id(DeviceUse::IS_X_POINTER)?;
 
         debug!(
-            "xtest_fake_input with coordinate {}, deviceid {}, x {}, y {}",
-            detail, deviceid, root_x, root_y
+            "xtest_fake_input with coordinate {}, deviceid {}, x {}, y {}, delay {}",
+            detail, deviceid, root_x, root_y, time
         );
 
         self.connection

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -243,6 +243,11 @@ impl KeyboardControllableNext for Con {
             })?;
 
         self.keymap.last_event_before_delays = std::time::Instant::now();
+
+        // Let the keymap know that the key was held/no longer held
+        // This is important to avoid unmapping held keys
+        self.keymap.enter_key(keycode, direction);
+
         Ok(())
     }
 }

--- a/src/linux/xdo.rs
+++ b/src/linux/xdo.rs
@@ -2,7 +2,7 @@ use std::{ffi::CString, ptr};
 
 use libc::{c_char, c_int, c_ulong, c_void, useconds_t};
 
-use log::{debug, error, warn};
+use log::debug;
 
 use crate::{
     Axis, Coordinate, Direction, InputError, InputResult, Key, KeyboardControllableNext,

--- a/src/linux/xdo.rs
+++ b/src/linux/xdo.rs
@@ -147,6 +147,10 @@ impl KeyboardControllableNext for Con {
                 "the text to enter contained a NULL byte ('\\0’), which is not allowed",
             ));
         };
+        debug!(
+            "xdo_enter_text_window with string {:?}, delay {}",
+            string, self.delay
+        );
         let res = unsafe {
             xdo_enter_text_window(
                 self.xdo,
@@ -181,30 +185,48 @@ impl KeyboardControllableNext for Con {
         };
 
         let res = match direction {
-            Direction::Click => unsafe {
-                xdo_send_keysequence_window(
-                    self.xdo,
-                    CURRENT_WINDOW,
-                    string.as_ptr(),
-                    self.delay as useconds_t,
-                )
-            },
-            Direction::Press => unsafe {
-                xdo_send_keysequence_window_down(
-                    self.xdo,
-                    CURRENT_WINDOW,
-                    string.as_ptr(),
-                    self.delay as useconds_t,
-                )
-            },
-            Direction::Release => unsafe {
-                xdo_send_keysequence_window_up(
-                    self.xdo,
-                    CURRENT_WINDOW,
-                    string.as_ptr(),
-                    self.delay as useconds_t,
-                )
-            },
+            Direction::Click => {
+                debug!(
+                    "xdo_send_keysequence_window with string {:?}, delay {}",
+                    string, self.delay
+                );
+                unsafe {
+                    xdo_send_keysequence_window(
+                        self.xdo,
+                        CURRENT_WINDOW,
+                        string.as_ptr(),
+                        self.delay as useconds_t,
+                    )
+                }
+            }
+            Direction::Press => {
+                debug!(
+                    "xdo_send_keysequence_window_down with string {:?}, delay {}",
+                    string, self.delay
+                );
+                unsafe {
+                    xdo_send_keysequence_window_down(
+                        self.xdo,
+                        CURRENT_WINDOW,
+                        string.as_ptr(),
+                        self.delay as useconds_t,
+                    )
+                }
+            }
+            Direction::Release => {
+                debug!(
+                    "xdo_send_keysequence_window_up with string {:?}, delay {}",
+                    string, self.delay
+                );
+                unsafe {
+                    xdo_send_keysequence_window_up(
+                        self.xdo,
+                        CURRENT_WINDOW,
+                        string.as_ptr(),
+                        self.delay as useconds_t,
+                    )
+                }
+            }
         };
         if res != XDO_SUCCESS {
             return Err(InputError::Simulate("unable to enter key"));
@@ -219,16 +241,20 @@ impl MouseControllableNext for Con {
         button: MouseButton,
         direction: Direction,
     ) -> InputResult<()> {
+        let mouse_button = mousebutton(button);
         let res = match direction {
-            Direction::Press => unsafe {
-                xdo_mouse_down(self.xdo, CURRENT_WINDOW, mousebutton(button))
-            },
-            Direction::Release => unsafe {
-                xdo_mouse_up(self.xdo, CURRENT_WINDOW, mousebutton(button))
-            },
-            Direction::Click => unsafe {
-                xdo_click_window(self.xdo, CURRENT_WINDOW, mousebutton(button))
-            },
+            Direction::Press => {
+                debug!("xdo_mouse_down with mouse button {}", mouse_button);
+                unsafe { xdo_mouse_down(self.xdo, CURRENT_WINDOW, mouse_button) }
+            }
+            Direction::Release => {
+                debug!("xdo_mouse_up with mouse button {}", mouse_button);
+                unsafe { xdo_mouse_up(self.xdo, CURRENT_WINDOW, mouse_button) }
+            }
+            Direction::Click => {
+                debug!("xdo_click_window with mouse button {}", mouse_button);
+                unsafe { xdo_click_window(self.xdo, CURRENT_WINDOW, mouse_button) }
+            }
         };
         if res != XDO_SUCCESS {
             return Err(InputError::Simulate("unable to enter mouse button"));
@@ -243,10 +269,14 @@ impl MouseControllableNext for Con {
         coordinate: Coordinate,
     ) -> InputResult<()> {
         let res = match coordinate {
-            Coordinate::Relative => unsafe {
-                xdo_move_mouse_relative(self.xdo, x as c_int, y as c_int)
-            },
-            Coordinate::Absolute => unsafe { xdo_move_mouse(self.xdo, x as c_int, y as c_int, 0) },
+            Coordinate::Relative => {
+                debug!("xdo_move_mouse_relative with x {}, y {}", x, y);
+                unsafe { xdo_move_mouse_relative(self.xdo, x as c_int, y as c_int) }
+            }
+            Coordinate::Absolute => {
+                debug!("xdo_move_mouse with mouse button with x {}, y {}", x, y);
+                unsafe { xdo_move_mouse(self.xdo, x as c_int, y as c_int, 0) }
+            }
         };
         if res != XDO_SUCCESS {
             return Err(InputError::Simulate("unable to move the mouse"));
@@ -278,6 +308,8 @@ impl MouseControllableNext for Con {
         const MAIN_SCREEN: i32 = 0;
         let mut width = 0;
         let mut height = 0;
+
+        debug!("xdo_get_viewport_dimensions");
         let res =
             unsafe { xdo_get_viewport_dimensions(self.xdo, &mut width, &mut height, MAIN_SCREEN) };
 
@@ -292,6 +324,7 @@ impl MouseControllableNext for Con {
         let mut y = 0;
         let mut unused_screen_index = 0;
         let mut unused_window_index = CURRENT_WINDOW;
+        debug!("xdo_get_mouse_location2");
         let res = unsafe {
             xdo_get_mouse_location2(
                 self.xdo,

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -363,17 +363,6 @@ impl KeyboardControllableNext for Enigo {
         if key == Key::Layout('\0') {
             return Ok(());
         }
-        match direction {
-            Direction::Press => {
-                debug!("added the key {key:?} to the held keys");
-                self.held.push(key);
-            }
-            Direction::Release => {
-                debug!("removed the key {key:?} from the held keys");
-                self.held.retain(|&k| k != key);
-            }
-            Direction::Click => (),
-        }
 
         let keycode = self.key_to_keycode(key);
 
@@ -400,6 +389,19 @@ impl KeyboardControllableNext for Enigo {
 
             event.post(CGEventTapLocation::HID);
         }
+
+        match direction {
+            Direction::Press => {
+                debug!("added the key {key:?} to the held keys");
+                self.held.push(key);
+            }
+            Direction::Release => {
+                debug!("removed the key {key:?} from the held keys");
+                self.held.retain(|&k| k != key);
+            }
+            Direction::Click => (),
+        }
+
         Ok(())
     }
 }

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -10,7 +10,7 @@ use core_graphics::event::{
     ScrollEventUnit,
 };
 use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
-use log::{debug, error, info, trace};
+use log::{debug, error, info};
 use objc::{class, msg_send, runtime::Class, sel, sel_impl};
 
 use crate::{

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -190,7 +190,7 @@ impl MouseControllableNext for Enigo {
             x_absolute,
             y_absolute,
         );
-        send_input(&vec![input])?;
+        send_input(&[input])?;
 
         // This also moves the mouse but is not subject to mouse accelleration
         // Sometimes the send_input is not enough
@@ -212,7 +212,7 @@ impl MouseControllableNext for Enigo {
             }
             Axis::Vertical => mouse_event(MOUSEEVENTF_WHEEL, -length * (WHEEL_DELTA as i32), 0, 0),
         };
-        send_input(&vec![input])?;
+        send_input(&[input])?;
         Ok(())
     }
 

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -297,17 +297,6 @@ impl KeyboardControllableNext for Enigo {
     fn enter_key(&mut self, key: Key, direction: Direction) -> InputResult<()> {
         debug!("\x1b[93menter_key(key: {key:?}, direction: {direction:?})\x1b[0m");
         let mut input = vec![];
-        match direction {
-            Direction::Press => {
-                debug!("added the key {key:?} to the held keys");
-                self.held.push(key);
-            }
-            Direction::Release => {
-                debug!("removed the key {key:?} from the held keys");
-                self.held.retain(|&k| k != key);
-            }
-            Direction::Click => (),
-        }
 
         if let Key::Layout(c) = key {
             // Handle special characters seperately
@@ -349,7 +338,21 @@ impl KeyboardControllableNext for Enigo {
                 input.push(keybd_event(keyflags | KEYEVENTF_KEYUP, keycode, 0u16));
             }
         };
-        send_input(&input)
+        send_input(&input)?;
+
+        match direction {
+            Direction::Press => {
+                debug!("added the key {key:?} to the held keys");
+                self.held.push(key);
+            }
+            Direction::Release => {
+                debug!("removed the key {key:?} from the held keys");
+                self.held.retain(|&k| k != key);
+            }
+            Direction::Click => (),
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
- Improved the logging messages on X11
- Only add the keys to the held keys once they were successfully pressed/released
- x11rb: Added a special case for modifiers so they can be successfully entered

Everything works as expected when using x11rb, but only as long as you did not press any modifiers before using any enigo functions. The modifier interact with the functions and unexpected things can can get entered