### PR TITLE
wayland: Fix simulating input in general

### DIFF
--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -549,11 +549,6 @@ impl KeyboardControllableNext for Con {
     }
 
     fn enter_key(&mut self, key: Key, direction: Direction) -> InputResult<()> {
-        let keycode = self.keymap.key_to_keycode(&(), key)?;
-
-        // Apply the new keymap if there were any changes
-        self.apply_keymap()?;
-
         // Send the events to the compositor
         if let Ok(modifier) = Modifier::try_from(key) {
             trace!("it is a modifier: {modifier:?}");
@@ -570,12 +565,15 @@ impl KeyboardControllableNext for Con {
                 self.send_modifier_event(modifiers)?;
             }
         } else {
-            self.send_key_event(keycode, direction)?;
-        }
+            let keycode = self.keymap.key_to_keycode(&(), key)?;
 
-        // Let the keymap know that the key was held/no longer held
-        // This is important to avoid unmapping held keys
-        self.keymap.enter_key(keycode, direction);
+            // Apply the new keymap if there were any changes
+            self.apply_keymap()?;
+            self.send_key_event(keycode, direction)?;
+            // Let the keymap know that the key was held/no longer held
+            // This is important to avoid unmapping held keys
+            self.keymap.enter_key(keycode, direction);
+        }
 
         Ok(())
     }

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -250,7 +250,10 @@ impl Con {
     /// Flush the Wayland queue
     fn flush(&self) -> InputResult<()> {
         match self.event_queue.flush() {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                trace!("flushed event queue");
+                Ok(())
+            }
             Err(e) => {
                 error!("{:?}", e);
                 Err(InputError::Simulate("could not flush wayland queue"))
@@ -279,6 +282,7 @@ impl Drop for Con {
         if self.flush().is_err() {
             error!("could not flush wayland queue");
         }
+        trace!("wayland objects were destroyed");
     }
 }
 
@@ -540,7 +544,7 @@ impl Drop for WaylandState {
 
 impl KeyboardControllableNext for Con {
     fn fast_text_entry(&mut self, text: &str) -> InputResult<Option<()>> {
-        if let Some((im, serial)) = &mut self.input_method {
+        if let Some((im, serial)) = self.input_method.as_mut() {
             is_alive(im)?;
             trace!("fast text input with imput_method protocol");
             im.commit_string(text.to_string());

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -196,12 +196,18 @@ impl Con {
             if direction == Direction::Press || direction == Direction::Click {
                 trace!("vk.key({time}, {keycode}, 1)");
                 vk.key(time, keycode, 1);
-                self.flush()?;
+                // TODO: Change to flush()
+                if self.event_queue.roundtrip(&mut self.state).is_err() {
+                    return Err(InputError::Simulate("The roundtrip on Wayland failed"));
+                }
             }
             if direction == Direction::Release || direction == Direction::Click {
                 trace!("vk.key({time}, {keycode}, 0)");
                 vk.key(time, keycode, 0);
-                self.flush()?;
+                // TODO: Change to flush()
+                if self.event_queue.roundtrip(&mut self.state).is_err() {
+                    return Err(InputError::Simulate("The roundtrip on Wayland failed"));
+                }
             }
             return Ok(());
         }
@@ -215,7 +221,10 @@ impl Con {
             is_alive(vk)?;
             trace!("vk.modifiers({modifiers}, 0, 0, 0)");
             vk.modifiers(modifiers, 0, 0, 0);
-            self.flush()?;
+            // TODO: Change to flush()
+            if self.event_queue.roundtrip(&mut self.state).is_err() {
+                return Err(InputError::Simulate("The roundtrip on Wayland failed"));
+            }
             return Ok(());
         }
         Err(InputError::Simulate("no way to enter modifier"))
@@ -240,7 +249,10 @@ impl Con {
             if let Some(keymap_size) = keymap_res {
                 trace!("update wayland keymap");
                 vk.keymap(1, self.keymap.file.as_ref().unwrap().as_fd(), keymap_size);
-                self.flush()?;
+                // TODO: Change to flush()
+                if self.event_queue.roundtrip(&mut self.state).is_err() {
+                    return Err(InputError::Simulate("The roundtrip on Wayland failed"));
+                }
             }
             return Ok(());
         }
@@ -283,6 +295,9 @@ impl Drop for Con {
             error!("could not flush wayland queue");
         }
         trace!("wayland objects were destroyed");
+
+        // TODO: Change to flush()
+        let _ = self.event_queue.roundtrip(&mut self.state);
     }
 }
 
@@ -550,7 +565,10 @@ impl KeyboardControllableNext for Con {
             im.commit_string(text.to_string());
             im.commit(*serial);
             *serial = serial.wrapping_add(1);
-            self.flush()?;
+            // TODO: Change to flush()
+            if self.event_queue.roundtrip(&mut self.state).is_err() {
+                return Err(InputError::Simulate("The roundtrip on Wayland failed"));
+            }
             return Ok(Some(()));
         }
         Ok(None)

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -160,8 +160,7 @@ impl Con {
                 "no protocol available to simulate input",
             ));
         }
-
-        Ok(Self {
+        let mut connection = Self {
             keymap,
             event_queue,
             state,
@@ -169,7 +168,12 @@ impl Con {
             input_method,
             virtual_pointer,
             base_time,
-        })
+        };
+
+        if connection.apply_keymap().is_err() {
+            return Err(NewConError::EstablishCon("unable to apply the keymap"));
+        };
+        Ok(connection)
     }
 
     /// Get the duration since the Keymap was created


### PR DESCRIPTION
I added more logging for the Wayland backend. The messages are now delivered to the Wayland server. Flush was not enough.

There is still the issue that modifiers do not work as expected. Control + a has no effect. Same as Shift + a. This is due to the keymap that is always used. Also 'a' gets mapped as an unnamed unicode keysym so it it different from the "regular" 'a'. This does not need to get fixed in this PR though.

`rust doc` fails building a dependency. This can get ignored. When it is ran with the `--no-deps` flag, it builds just fine.