### PR TITLE
all: Hide and rename `fast_text_entry` fn 

### DIFF
--- a/.github/actions/install_deps/action.yml
+++ b/.github/actions/install_deps/action.yml
@@ -7,7 +7,6 @@ runs:
     - name:  Install dependencies
       run:   |
         if [ "$RUNNER_OS" == "Linux" ]; then
-          sudo apt-mark hold grub-efi-amd64-signed # TODO: Remove temporary fix
           sudo apt-get update -q -y && sudo apt-get upgrade -y
           sudo apt-get install -y libxdo-dev libxkbcommon-dev
           echo "$RUNNER_OS"

--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -1050,4 +1050,4 @@ impl TryFrom<Key> for Modifier {
 
 #[cfg(target_os = "linux")]
 #[cfg(any(feature = "wayland", feature = "x11rb"))]
-pub(crate) type ModifierBitflag = u32; // TODO: Maybe create a proper type for this
+pub(crate) type ModifierBitflag = u32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,8 @@ impl DSL for Enigo {}
 /// on the layout/keymap.
 #[doc(alias = "KeyboardControllable")]
 pub trait Keyboard {
-    // TODO: Remove this from the trait (should not be public)
+    /// Do not use this directly. Use the [`Keyboard::text`] function.
+    ///
     /// Enter the whole text string instead of entering individual keys
     /// This is much faster if you type longer text at the cost of keyboard
     /// shortcuts not getting recognized.
@@ -197,7 +198,8 @@ pub trait Keyboard {
     /// # Errors
     /// Have a look at the documentation of [`InputError`] to see under which
     /// conditions an error will be returned.
-    fn fast_text_entry(&mut self, text: &str) -> InputResult<Option<()>>;
+    #[doc(hidden)]
+    fn fast_text(&mut self, text: &str) -> InputResult<Option<()>>;
 
     /// Enter the text
     /// Use a fast method to enter the text, if it is available. You can use
@@ -218,7 +220,7 @@ pub trait Keyboard {
         }
 
         // Fall back to entering single keys if no fast text entry is available
-        let fast_text_res = self.fast_text_entry(text);
+        let fast_text_res = self.fast_text(text);
         match fast_text_res {
             Ok(Some(())) => {
                 debug!("fast text entry was successful");

--- a/src/linux/keymap.rs
+++ b/src/linux/keymap.rs
@@ -250,7 +250,6 @@ where
     /// regenerated
     fn make_room<C: Bind<Keycode>>(&mut self, c: &C) -> InputResult<()> {
         // Unmap all keys, if all keycodes are already being used
-        // TODO: Don't unmap the keycodes if they will be needed next
         if self.unused_keycodes.is_empty() {
             let mapped_keys = self.additionally_mapped.clone();
             let held_keycodes = self.held_keycodes.clone();
@@ -280,8 +279,7 @@ where
     pub fn regenerate(&mut self) -> Result<Option<u32>, std::io::Error> {
         use super::{KEYMAP_BEGINNING, KEYMAP_END};
         use std::io::{Seek, SeekFrom, Write};
-        use xkbcommon::xkb::keysym_get_name; // TODO: Replace this with the function from xkeysym and get rid of the
-                                             // xkbcommon dependency once the functions return the same results
+        use xkbcommon::xkb::keysym_get_name;
 
         // Don't do anything if there were no changes
         if !self.needs_regeneration {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -114,7 +114,7 @@ impl Enigo {
         if let Some(con) = self.x11.as_ref() {
             return con.delay();
         }
-        0 // TODO: Make this an Option
+        0
     }
 
     /// Set the delay per keypress
@@ -242,8 +242,8 @@ impl Mouse for Enigo {
 }
 
 impl Keyboard for Enigo {
-    fn fast_text_entry(&mut self, text: &str) -> InputResult<Option<()>> {
-        debug!("\x1b[93mfast_text_entry(text: {text})\x1b[0m");
+    fn fast_text(&mut self, text: &str) -> InputResult<Option<()>> {
+        debug!("\x1b[93mfast_text(text: {text})\x1b[0m");
         #[cfg(feature = "wayland")]
         if let Some(con) = self.wayland.as_mut() {
             trace!("try entering text fast via wayland");

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -112,7 +112,6 @@ impl Con {
             unused_keycodes.push_back(n as Keycode);
         }
 
-        // TODO: Double check this and adjust it
         let (keysyms_per_keycode, keysyms) = (0, vec![]);
         let keymap = KeyMap::new(8, 255, unused_keycodes, keysyms_per_keycode, keysyms);
 
@@ -568,7 +567,7 @@ impl Drop for WaylandState {
 }
 
 impl Keyboard for Con {
-    fn fast_text_entry(&mut self, text: &str) -> InputResult<Option<()>> {
+    fn fast_text(&mut self, text: &str) -> InputResult<Option<()>> {
         if let Some((im, serial)) = self.input_method.as_mut() {
             is_alive(im)?;
             trace!("fast text input with imput_method protocol");

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -242,7 +242,7 @@ impl Bind<Keycode> for CompositorConnection {
 }
 
 impl Keyboard for Con {
-    fn fast_text_entry(&mut self, _text: &str) -> InputResult<Option<()>> {
+    fn fast_text(&mut self, _text: &str) -> InputResult<Option<()>> {
         warn!("fast text entry is not yet implemented with x11rb");
         // TODO: Add fast method
         // xdotools can do it, so it is possible

--- a/src/linux/xdo.rs
+++ b/src/linux/xdo.rs
@@ -140,7 +140,7 @@ impl Drop for Con {
 }
 
 impl Keyboard for Con {
-    fn fast_text_entry(&mut self, text: &str) -> InputResult<Option<()>> {
+    fn fast_text(&mut self, text: &str) -> InputResult<Option<()>> {
         let Ok(string) = CString::new(text) else {
             return Err(InputError::InvalidInput(
                 "the text to enter contained a NULL byte ('\\0’), which is not allowed",

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -216,8 +216,6 @@ impl Mouse for Enigo {
         Ok(())
     }
 
-    // Sends a motion notify event to the X11 server via `XTest` extension
-    // TODO: Check if using x11rb::protocol::xproto::warp_pointer would be better
     fn move_mouse(&mut self, x: i32, y: i32, coordinate: Coordinate) -> InputResult<()> {
         debug!("\x1b[93mmove_mouse(x: {x:?}, y: {y:?}, coordinate:{coordinate:?})\x1b[0m");
         let pressed = Self::pressed_buttons()?;
@@ -305,7 +303,7 @@ impl Mouse for Enigo {
 
 // https://stackoverflow.com/questions/1918841/how-to-convert-ascii-character-to-cgkeycode
 impl Keyboard for Enigo {
-    fn fast_text_entry(&mut self, text: &str) -> InputResult<Option<()>> {
+    fn fast_text(&mut self, text: &str) -> InputResult<Option<()>> {
         // Fn to create an iterator over sub slices of a str that have the specified
         // length
         fn chunks(s: &str, len: usize) -> impl Iterator<Item = &str> {
@@ -327,7 +325,7 @@ impl Keyboard for Enigo {
             })
         }
 
-        debug!("\x1b[93mfast_text_entry(text: {text})\x1b[0m");
+        debug!("\x1b[93mfast_text(text: {text})\x1b[0m");
         // NOTE(dustin): This is a fix for issue https://github.com/enigo-rs/enigo/issues/68
         // The CGEventKeyboardSetUnicodeString function (used inside of
         // event.set_string(chunk)) truncates strings down to 20 characters

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -124,8 +124,6 @@ impl Mouse for Enigo {
         send_input(&input)
     }
 
-    // Sends a motion notify event to the X11 server via `XTest` extension
-    // TODO: Check if using x11rb::protocol::xproto::warp_pointer would be better
     fn move_mouse(&mut self, x: i32, y: i32, coordinate: Coordinate) -> InputResult<()> {
         debug!("\x1b[93mmove_mouse(x: {x:?}, y: {y:?}, coordinate:{coordinate:?})\x1b[0m");
         let (x_absolute, y_absolute) = if coordinate == Coordinate::Rel {
@@ -196,7 +194,7 @@ impl Mouse for Enigo {
 }
 
 impl Keyboard for Enigo {
-    fn fast_text_entry(&mut self, _text: &str) -> InputResult<Option<()>> {
+    fn fast_text(&mut self, _text: &str) -> InputResult<Option<()>> {
         Ok(None)
     }
 


### PR DESCRIPTION
The `fast_text_entry` fn was renamed to `fast_text`. It should never be used directly so it was hidden from the docs