### PR TITLE
All: Allow using unlisted keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enigo"
-version = "0.2.0-rc1"
+version = "0.2.0-rc2"
 authors = [
     "pentamassiv <pentamassiv@posteo.de>",
     "Dustin Bensing <dustin.bensing@googlemail.com>",


### PR DESCRIPTION
The list of keys that users should be able to press is longer than the list we have. This allows pressing keys that are not listed, if the user knows their corresponding value