### PR TITLE
Move objc dependency to icrate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,8 @@ windows = { version = "0.51", features = [
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = "0.9"
 core-graphics = { version = "0.23", features = ["highsierra"] }
-objc = "0.2"
+icrate = { version = "0.0.4", features = ["AppKit_all"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -21,7 +21,12 @@ fn main() {
     println!("{time:?}");
 
     // select all
-    enigo.key(Key::Control, Press).unwrap();
+    let control_or_command = if cfg!(target_os = "macos") {
+        Key::Meta
+    } else {
+        Key::Control
+    };
+    enigo.key(control_or_command, Press).unwrap();
     enigo.key(Key::Unicode('a'), Click).unwrap();
-    enigo.key(Key::Control, Release).unwrap();
+    enigo.key(control_or_command, Release).unwrap();
 }


### PR DESCRIPTION
I'm opening this PR related to #249, but as it's my first contribution, I wanna take time to clear some doubts.

On [macos_impl.rs:468](https://github.com/paulora2405/enigo/blob/47a437a71d47fc6f2b125b397e07befb98cb06a3/src/macos/macos_impl.rs#L468) I had to add a  `allow` directive because using the `icrate` crate, I'm no longer required to create a `Class`, and thus, apparently cannot fail the `NSEvent` call, so I unnecessarily return a result from an infallible code. I'm not really sure this is the best approach.

Another thing is, I've opted to go with `icrate` instead of `objc2` directly, this is because, the code didn't really need that low of an access to Objective-C, so I figured that the better ergonomics of `icrate` would benefit the project in terms of simplicity.

One more thing is, should the usage of the `core_graphics` crate be kept? I'm not 100% sure, but I think that the `objc2` project (not the crate) has a substitute for this crate as well. If that's true, maybe I could give it a go trying to switch to it too.

I've also fixed the `timer.rs` example, which had an target specific key being used in a general way.