### PR TITLE
macOS: Added workaround for entering text that starts with newline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@
 - linux: You can enter `Key::ScrollLock` now
 - win: No more sleeps! Simulating input is done in 1 ms instead of 40+ ms. This is most obvious when entering long strings
 - macOS: Added keys to control media, brightness, contrast, illumination and more
+- macOS: Fix entering text that starts with newline characters
 
 # 0.1.3
 


### PR DESCRIPTION
Fixes https://github.com/enigo-rs/enigo/issues/260

I am not sure if there is an issue with the rust bindings or the underlying system API, but there is an issue entering strings on macOS that start with a newline character. The workaround will check if the string starts with a newline and will instead simulate the return key. I hope it does not cause any unexpected side effects