### PR TITLE
Bump `windows` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ log = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.51", features = [
+windows = { version = "0.54", features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Input_KeyboardAndMouse",

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -58,7 +58,8 @@ fn mouse_event(flags: MOUSE_EVENT_FLAGS, data: i32, dx: i32, dy: i32) -> INPUT {
             mi: MOUSEINPUT {
                 dx,
                 dy,
-                mouseData: data,
+                mouseData: data as u32, /* mouseData unfortunately is defined as unsigned even
+                                         * though we need negative values as well */
                 dwFlags: flags,
                 time: 0, /* Always set it to 0 (see https://web.archive.org/web/20231004113147/https://devblogs.microsoft.com/oldnewthing/20121101-00/?p=6193) */
                 dwExtraInfo: 0,


### PR DESCRIPTION
Bump the dependency. The type of `mouseData` was intentionally changed from `i32` to `u32`, even though we have to pass negative values as well. This is not considered a bug (see https://github.com/microsoft/win32metadata/issues/1865).