### PR TITLE
Add a empty Enigo type on unsupported platforms

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,49 @@
+use crate::{Keyboard, Mouse};
+
+enum Never {}
+
+pub struct Enigo {
+    never: Never,
+}
+
+impl Mouse for Enigo {
+    fn button(&mut self, _: crate::Button, _: crate::Direction) -> crate::InputResult<()> {
+        match self.never {}
+    }
+
+    fn move_mouse(&mut self, _: i32, _: i32, _: crate::Coordinate) -> crate::InputResult<()> {
+        match self.never {}
+    }
+
+    fn scroll(&mut self, _: i32, _: crate::Axis) -> crate::InputResult<()> {
+        match self.never {}
+    }
+
+    fn main_display(&self) -> crate::InputResult<(i32, i32)> {
+        match self.never {}
+    }
+
+    fn location(&self) -> crate::InputResult<(i32, i32)> {
+        match self.never {}
+    }
+}
+
+impl Keyboard for Enigo {
+    fn fast_text(&mut self, _: &str) -> crate::InputResult<Option<()>> {
+        match self.never {}
+    }
+
+    fn key(&mut self, _: crate::Key, _: crate::Direction) -> crate::InputResult<()> {
+        match self.never {}
+    }
+
+    fn raw(&mut self, _: u16, _: crate::Direction) -> crate::InputResult<()> {
+        match self.never {}
+    }
+}
+
+impl Drop for Enigo {
+    fn drop(&mut self) {
+        match self.never {}
+    }
+}


### PR DESCRIPTION
Currently the code doesn't compile on unsupported platforms due to the following code:

https://github.com/enigo-rs/enigo/blob/c350b71fd68fe92340105d324806150e831d51ed/src/lib.rs#L67-L71

I added a default mod file `platform.rs`, which will be compiled when the platform is not supported. In this file, `Enigo` is an [empty type](https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types) which cannot be instantiated.

Thus, `Enigo::new` is only implemented on supported platforms. Developers would see compile error when trying to instantiate `Enigo` on unsupported platforms.

Traits like `Keyboard`, `Mouse` and `Drop` are implemented just like on supported platforms.
In this way, library developers can use the platform agnostic `Enigo` type.