### PR TITLE
all: Add serde aliases to make serialized tokens less verbose

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 ## Changed
 
 ## Added
+all: Serialized tokens can be less verbose because serde aliases were added
 win, macOS: Allow marking events that were created by enigo. Have a look at the additional field of the `Settings` struct and the new method `get_marker_value` of the `enigo` struct (only available on Windows and macOS)
 
 ## Fixed

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -22,6 +22,10 @@ fn main() {
         Token::Key(Key::Control, enigo::Direction::Release),
     ];
 
+    // There are serde aliases so you could also deserialize the same tokens from
+    // the following string let serialized=r#"[t("Hello World!
+    // ❤\u{fe0f}"),m(10,10,r),s(5,v),b(l,c),k(uni('🔥'),c),k(ctrl,p),k(uni('a'),c),
+    // k(ctrl,r)]"#.to_string();
     let serialized = ron::to_string(&tokens).unwrap();
     println!("serialized = {serialized}");
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -7,19 +7,31 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Token {
     /// Call the [`Keyboard::text`] fn with the string as text
+    #[cfg_attr(feature = "serde", serde(alias = "T"))]
+    #[cfg_attr(feature = "serde", serde(alias = "t"))]
     Text(String),
     /// Call the [`Keyboard::key`] fn with the given key and direction
+    #[cfg_attr(feature = "serde", serde(alias = "K"))]
+    #[cfg_attr(feature = "serde", serde(alias = "k"))]
     Key(Key, Direction),
     /// Call the [`Keyboard::raw`] fn with the given keycode and direction
+    #[cfg_attr(feature = "serde", serde(alias = "R"))]
+    #[cfg_attr(feature = "serde", serde(alias = "r"))]
     Raw(u16, Direction),
     /// Call the [`Mouse::button`] fn with the given mouse button and direction
+    #[cfg_attr(feature = "serde", serde(alias = "B"))]
+    #[cfg_attr(feature = "serde", serde(alias = "b"))]
     Button(Button, Direction),
     /// Call the [`Mouse::move_mouse`] fn. The first i32 is the value to move on
     /// the x-axis and the second i32 is the value to move on the y-axis. The
     /// coordinate defines if the given coordinates are absolute of relative to
     /// the current position of the mouse.
+    #[cfg_attr(feature = "serde", serde(alias = "M"))]
+    #[cfg_attr(feature = "serde", serde(alias = "m"))]
     MoveMouse(i32, i32, Coordinate),
     /// Call the [`Mouse::scroll`] fn.
+    #[cfg_attr(feature = "serde", serde(alias = "S"))]
+    #[cfg_attr(feature = "serde", serde(alias = "s"))]
     Scroll(i32, Axis),
 }
 

--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -130,12 +130,14 @@ pub enum Key {
     Clear,
     #[deprecated(since = "0.0.12", note = "now renamed to Meta")]
     /// command key on macOS (super key on Linux, windows key on Windows)
+    #[cfg_attr(feature = "serde", serde(alias = "cmd"))]
     Command,
     #[cfg(target_os = "macos")]
     ContrastUp,
     #[cfg(target_os = "macos")]
     ContrastDown,
     /// control key
+    #[cfg_attr(feature = "serde", serde(alias = "ctrl"))]
     Control,
     #[cfg(target_os = "windows")]
     Convert,
@@ -598,6 +600,10 @@ pub enum Key {
     Zoom,
     /// Unicode character
     #[doc(alias = "Layout")]
+    #[cfg_attr(feature = "serde", serde(alias = "uni"))]
+    #[cfg_attr(feature = "serde", serde(alias = "Uni"))]
+    #[cfg_attr(feature = "serde", serde(alias = "Char"))]
+    #[cfg_attr(feature = "serde", serde(alias = "char"))]
     Unicode(char),
     /// Use this for keys that are not listed here that you know the
     /// value of. Let us know if you think the key should be listed so
@@ -1032,13 +1038,27 @@ impl TryFrom<Key> for windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum Modifier {
+    #[cfg_attr(feature = "serde", serde(alias = "shift"))]
     Shift,
+    #[cfg_attr(feature = "serde", serde(alias = "lock"))]
     Lock,
+    #[cfg_attr(feature = "serde", serde(alias = "control"))]
+    #[cfg_attr(feature = "serde", serde(alias = "crtl"))]
     Control,
+    #[cfg_attr(feature = "serde", serde(alias = "mod1"))]
+    #[cfg_attr(feature = "serde", serde(alias = "m1"))]
     Mod1,
+    #[cfg_attr(feature = "serde", serde(alias = "mod2"))]
+    #[cfg_attr(feature = "serde", serde(alias = "m2"))]
     Mod2,
+    #[cfg_attr(feature = "serde", serde(alias = "mod3"))]
+    #[cfg_attr(feature = "serde", serde(alias = "m3"))]
     Mod3,
+    #[cfg_attr(feature = "serde", serde(alias = "mod4"))]
+    #[cfg_attr(feature = "serde", serde(alias = "m4"))]
     Mod4,
+    #[cfg_attr(feature = "serde", serde(alias = "mod5"))]
+    #[cfg_attr(feature = "serde", serde(alias = "m5"))]
     Mod5,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,41 +80,59 @@ pub use keycodes::Key;
 /// Arbitrary value to be able to distinguish events created by enigo
 pub const EVENT_MARKER: u32 = 100;
 
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Represents a mouse button and is used in e.g
 /// [`Mouse::button`].
 
 // Warning! If there are ANY CHANGES to this enum, we
 // need to change the size of the array in the macOS implementation of the Enigo
 // struct that stores the nth click for each Button
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[doc(alias = "MouseButton")]
 pub enum Button {
     /// Left mouse button
+    #[cfg_attr(feature = "serde", serde(alias = "L"))]
+    #[cfg_attr(feature = "serde", serde(alias = "l"))]
     Left,
     /// Middle mouse button
+    #[cfg_attr(feature = "serde", serde(alias = "M"))]
+    #[cfg_attr(feature = "serde", serde(alias = "m"))]
     Middle,
     /// Right mouse button
+    #[cfg_attr(feature = "serde", serde(alias = "R"))]
+    #[cfg_attr(feature = "serde", serde(alias = "r"))]
     Right,
-    #[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
     /// 4th mouse button. Typically performs the same function as `Browser_Back`
-    Back,
     #[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
+    #[cfg_attr(feature = "serde", serde(alias = "B"))]
+    #[cfg_attr(feature = "serde", serde(alias = "b"))]
+    Back,
     /// 5th mouse button. Typically performs the same function as
     /// `Browser_Forward`
+    #[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
+    #[cfg_attr(feature = "serde", serde(alias = "F"))]
+    #[cfg_attr(feature = "serde", serde(alias = "f"))]
     Forward,
 
     /// Scroll up button. It is better to use the
     /// [`Mouse::scroll`] method to scroll.
+    #[cfg_attr(feature = "serde", serde(alias = "SU"))]
+    #[cfg_attr(feature = "serde", serde(alias = "su"))]
     ScrollUp,
     /// Scroll down button. It is better to use the
     /// [`Mouse::scroll`] method to scroll.
+    #[cfg_attr(feature = "serde", serde(alias = "SD"))]
+    #[cfg_attr(feature = "serde", serde(alias = "sd"))]
     ScrollDown,
     /// Scroll left button. It is better to use the
     /// [`Mouse::scroll`] method to scroll.
+    #[cfg_attr(feature = "serde", serde(alias = "SL"))]
+    #[cfg_attr(feature = "serde", serde(alias = "sl"))]
     ScrollLeft,
     /// Scroll right button. It is better to use the
     /// [`Mouse::scroll`] method to scroll.
+    #[cfg_attr(feature = "serde", serde(alias = "SR"))]
+    #[cfg_attr(feature = "serde", serde(alias = "sr"))]
     ScrollRight,
 }
 
@@ -124,13 +142,19 @@ impl fmt::Debug for Enigo {
     }
 }
 
+/// The direction of a key or button
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-/// The direction of a key or button
 pub enum Direction {
+    #[cfg_attr(feature = "serde", serde(alias = "P"))]
+    #[cfg_attr(feature = "serde", serde(alias = "p"))]
     Press,
+    #[cfg_attr(feature = "serde", serde(alias = "R"))]
+    #[cfg_attr(feature = "serde", serde(alias = "r"))]
     Release,
     /// Equivalent to a press followed by a release
+    #[cfg_attr(feature = "serde", serde(alias = "C"))]
+    #[cfg_attr(feature = "serde", serde(alias = "c"))]
     Click,
 }
 
@@ -138,7 +162,11 @@ pub enum Direction {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Specifies the axis for scrolling
 pub enum Axis {
+    #[cfg_attr(feature = "serde", serde(alias = "H"))]
+    #[cfg_attr(feature = "serde", serde(alias = "h"))]
     Horizontal,
+    #[cfg_attr(feature = "serde", serde(alias = "V"))]
+    #[cfg_attr(feature = "serde", serde(alias = "v"))]
     Vertical,
 }
 
@@ -147,8 +175,12 @@ pub enum Axis {
 /// Specifies if a coordinate is relative or absolute
 pub enum Coordinate {
     #[doc(alias = "Absolute")]
+    #[cfg_attr(feature = "serde", serde(alias = "A"))]
+    #[cfg_attr(feature = "serde", serde(alias = "a"))]
     Abs,
     #[doc(alias = "Relative")]
+    #[cfg_attr(feature = "serde", serde(alias = "R"))]
+    #[cfg_attr(feature = "serde", serde(alias = "r"))]
     Rel,
 }
 


### PR DESCRIPTION
The DSL was replaced by using serde to serialize and deserialize tokens. The serialized strings are more verbose. I've added serde aliases so that users don't have to type much more than before. This shortens the serialized string from the serde example from:

```
[Text("Hello World! ❤\u{fe0f}"),MoveMouse(10,10,Rel),Scroll(5,Vertical),Button(Left,Click),Key(Unicode('🔥'),Click),Key(Control,Press),Key(Unicode('a'),Click),Key(Control,Release)]
```

to:

```
[t("Hello World! ❤\u{fe0f}"),m(10,10,r),s(5,v),b(l,c),k(uni('🔥'),c),k(ctrl,p),k(uni('a'),c),k(ctrl,r)]
```