### PR TITLE
Fix being unable to type uppercase characters on Windows

### DIFF
--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -5,10 +5,11 @@ use windows::Win32::Foundation::POINT;
 use windows::Win32::UI::Input::KeyboardAndMouse::{
     MapVirtualKeyW, SendInput, VkKeyScanW, INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBDINPUT,
     KEYBD_EVENT_FLAGS, KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, KEYEVENTF_SCANCODE,
-    KEYEVENTF_UNICODE, MAP_VIRTUAL_KEY_TYPE, MOUSEEVENTF_ABSOLUTE, MOUSEEVENTF_HWHEEL,
+    KEYEVENTF_UNICODE, MAPVK_VK_TO_VSC, MOUSEEVENTF_ABSOLUTE, MOUSEEVENTF_HWHEEL,
     MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP,
     MOUSEEVENTF_MOVE, MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_WHEEL,
-    MOUSEEVENTF_XDOWN, MOUSEEVENTF_XUP, MOUSEINPUT, MOUSE_EVENT_FLAGS, VIRTUAL_KEY,
+    MOUSEEVENTF_XDOWN, MOUSEEVENTF_XUP, MOUSEINPUT, MOUSE_EVENT_FLAGS, SCANCODE_ALT, SCANCODE_CTRL,
+    SCANCODE_LSHIFT, SCANCODE_THAI_LAYOUT_TOGGLE, VIRTUAL_KEY,
 };
 
 use windows::Win32::UI::WindowsAndMessaging::{
@@ -441,8 +442,34 @@ impl Enigo {
                     ));
                 }
             };
+
+            let key_hi = keystate >> 8;
+            let key_lo = keystate & 0xFF;
+
+            // Translate the shift state flags to scancodes
+            if key_hi & 1 != 0 {
+                // "Either SHIFT key is pressed."
+                // "...does not distinguish between left- and right-hand keys,
+                //    the left-hand scan code is returned..."
+                scancodes.push(SCANCODE_LSHIFT as u16);
+            }
+            if key_hi & 2 != 0 {
+                // "Either CTRL key is pressed."
+                scancodes.push(SCANCODE_CTRL as u16);
+            }
+            if key_hi & 4 != 0 {
+                // "Either ALT key is pressed."
+                scancodes.push(SCANCODE_ALT as u16);
+            }
+            if key_hi & 8 != 0 {
+                // Looked it up, seems like "The Hankaku key is pressed" does code 0x29 (41).
+                // This constant matches that value (41u32).
+                scancodes.push(SCANCODE_THAI_LAYOUT_TOGGLE as u16);
+            }
+            // `& 16`, `& 32`: "Reserved (defined by the keyboard layout driver)."
+
             // Translate the virtual-key code to a scan code
-            match unsafe { MapVirtualKeyW(keystate, MAP_VIRTUAL_KEY_TYPE(0)) }.try_into() {
+            match unsafe { MapVirtualKeyW(key_lo, MAPVK_VK_TO_VSC) }.try_into() {
                 // If there is no translation, the return value is zero
                 Ok(0) => {
                     return Err(InputError::Mapping("Could not translate the character to the corresponding virtual-key code and shift state for the current keyboard".to_string()));


### PR DESCRIPTION
Fixes the problem with Windows being unable to type out uppercase characters when using `Key::Unicode` keys (e.g. `Key::Unicode('T')`).

Upon using the `key` function that types out `Unicode` keys for uppercase characters, the call returns the error below:

```text
error when mapping keycode to keysym: (Could not translate the character to the corresponding virtual-key code and shift state for the current keyboard)
```

Apparently the call for `VkKeyScanW` in enigo's code does not handle the uppercase characters: the code is translated into two bytes (as huge comment above the call mentions) as a single `u32` (upper `u16` of which isn't used?), which later was not handled and passed over to `MapVirtualKeyW`, which fails because it cannot translate two-byte value (e.g. `340` for `'T'`) into a scancode. This PR handles the two bytes by emitting extra necessary scancodes (e.g. `SCANCODE_LSHIFT`) depending on the flags in the high-order byte.

P.S. Why does Windows implementation mention keysym in its errors?