### PR TITLE
macOS: Add fallback to ASCII-capable keyboard layout for handling non-standard input sources

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - all: `Key::PrintScr`
 - all: There finally are some tests in the CI to increase the development speed and prevent regressions
 - win, macOS: Allow marking events that were created by enigo. Have a look at the additional field of the `Settings` struct and the new method `get_marker_value` of the `enigo` struct (only available on Windows and macOS)
+- macOS: Fallback to ASCII-capable keyboard layout for handling non-standard input sources
 
 ## Fixed
 win: Respect the language of the current window to determine the which scancodes to send

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -87,6 +87,7 @@ const kCFStringEncodingUTF8: u32 = 0x0800_0100;
 extern "C" {
     fn TISCopyCurrentKeyboardInputSource() -> TISInputSourceRef;
     fn TISCopyCurrentKeyboardLayoutInputSource() -> TISInputSourceRef;
+    fn TISCopyCurrentASCIICapableKeyboardLayoutInputSource() -> TISInputSourceRef;
 
     #[allow(non_upper_case_globals)]
     static kTISPropertyUnicodeKeyLayoutData: CFStringRef;
@@ -847,6 +848,15 @@ fn create_string_for_key(keycode: u16, modifier: u32) -> CFStringRef {
             TISGetInputSourceProperty(current_keyboard, kTISPropertyUnicodeKeyLayoutData)
         };
         debug_assert!(!layout_data.is_null());
+    }
+    if layout_data.is_null() {
+        debug!("TISGetInputSourceProperty(current_keyboard, kTISPropertyUnicodeKeyLayoutData) returned NULL again");
+        current_keyboard = unsafe { TISCopyCurrentASCIICapableKeyboardLayoutInputSource() };
+        layout_data = unsafe {
+            TISGetInputSourceProperty(current_keyboard, kTISPropertyUnicodeKeyLayoutData)
+        };
+        debug_assert!(!layout_data.is_null());
+        debug!("Using layout of the TISCopyCurrentASCIICapableKeyboardLayoutInputSource");
     }
     let keyboard_layout = unsafe { CFDataGetBytePtr(layout_data) };
 


### PR DESCRIPTION
Added an additional fallback in `create_string_for_key()` to handle cases where `TISGetInputSourceProperty` returns `NULL` after switching to the default keyboard layout via `TISCopyCurrentKeyboardLayoutInputSource()`.

This fallback calls `TISCopyCurrentASCIICapableKeyboardLayoutInputSource()` to ensure that an ASCII-capable layout is used when the system's current layout does not provide valid Unicode key layout data. This increases robustness when dealing with non-standard or custom keyboard layouts, preventing potential failures during input simulation.