### PR TITLE
Tests: Expect only one Text message from the websocket when testing text()

### DIFF
--- a/tests/common/enigo_test.rs
+++ b/tests/common/enigo_test.rs
@@ -91,13 +91,13 @@ impl Keyboard for EnigoTest {
         std::thread::sleep(std::time::Duration::from_millis(INPUT_DELAY)); // Wait for input to have an effect
         self.send_message("GetText");
 
-        loop {
-            if let BrowserEvent::Text(received_text) = self.read_message() {
-                println!("received text: {received_text}");
-                assert_eq!(text, received_text);
-                break;
-            }
+        if let BrowserEvent::Text(received_text) = self.read_message() {
+            println!("received text: {received_text}");
+            assert_eq!(text, received_text);
+        } else {
+            panic!("BrowserEvent was not a Text: {received_text:?}");
         }
+
         res.map(Some) // TODO: Check if this is always correct
     }
 

--- a/tests/common/enigo_test.rs
+++ b/tests/common/enigo_test.rs
@@ -91,11 +91,12 @@ impl Keyboard for EnigoTest {
         std::thread::sleep(std::time::Duration::from_millis(INPUT_DELAY)); // Wait for input to have an effect
         self.send_message("GetText");
 
-        if let BrowserEvent::Text(received_text) = self.read_message() {
+        let ev = self.read_message();
+        if let BrowserEvent::Text(received_text) = ev {
             println!("received text: {received_text}");
             assert_eq!(text, received_text);
         } else {
-            panic!("BrowserEvent was not a Text: {received_text:?}");
+            panic!("BrowserEvent was not a Text: {ev:?}");
         }
 
         res.map(Some) // TODO: Check if this is always correct

--- a/tests/index.html
+++ b/tests/index.html
@@ -25,6 +25,8 @@
     <textarea id="text" name="text" rows="20" cols="50"></textarea><br>
 
     <script>
+        let ignoreKeyEvents = false; // Flag to ignore key events
+
         // Focus on the textarea when the page loads
         window.onload = () => {
             const textArea = document.getElementById('text');
@@ -52,8 +54,21 @@
 
         document.addEventListener('open', (event) => handleEvent('Open', event));
         document.addEventListener('close', (event) => handleEvent('Close', event));
-        document.addEventListener('keydown', (event) => handleEvent('KeyDown', `(\"${event.key}\")`));
-        document.addEventListener('keyup', (event) => handleEvent('KeyUp', `(\"${event.key}\")`));
+        
+        // Handle keydown events but ignore if flag is set
+        document.addEventListener('keydown', (event) => {
+            if (!ignoreKeyEvents) {
+                handleEvent('KeyDown', `(\"${event.key}\")`);
+            }
+        });
+
+        // Handle keyup events but ignore if flag is set
+        document.addEventListener('keyup', (event) => {
+            if (!ignoreKeyEvents) {
+                handleEvent('KeyUp', `(\"${event.key}\")`);
+            }
+        });
+
         document.addEventListener('mousedown', (event) => handleEvent('MouseDown', `(${event.button})`));
         document.addEventListener('mouseup', (event) => handleEvent('MouseUp', `(${event.button})`));
         document.addEventListener('mousemove', (event) => handleEvent('MouseMove', `((${event.movementX},${event.movementY}),(${event.screenX},${event.screenY}))`));
@@ -67,6 +82,8 @@
             if (event.data === 'ClearText') {
                 document.getElementById('text').value = '';
                 document.getElementById('text').focus();
+                // Set flag to ignore key events
+                ignoreKeyEvents = true;
                 // Send the input text via WebSocket
                 ws.send(`ReadyForText`);
             }
@@ -77,6 +94,9 @@
 
                 // Send the form's content via WebSocket
                 ws.send(`Text(\"${text}\")`);
+
+                // Reset flag after sending text, allowing key events again
+                ignoreKeyEvents = false;
             }
         });
     </script>


### PR DESCRIPTION
Depending on the implementation and the operating system, Firefox would previously send multiple Key events that were ignored until there was a Text event. This is a bit hacky so the JS of the test page was changed to not send any Key events between receiving a ClearText and a GetText message