### PR TITLE
macOS: Simulated input is independent of the physical keyboard state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Unreleased
 ## Changed
 - all: The keys `Print` and `Snapshot` were deprecated because `Print` had the wrong virtual key associated with it on Windows. Use `Key::PrintScr` instead
+- macOS: The simulated input is no longer effected by the state of the physical keyboard. This default behavior can be changed via the Settings (`independent_of_keyboard_state`)
 
 ## Added
 - all: `Key::PrintScr`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,9 @@
 - macOS: Check if the application has the neccessary permissions. If they are missing, `enigo` will ask the user to grant them. You can change this default behavior with the `Settings` when constructing an `Enigo` struct.
 
 ## Fixed
-win: Respect the language of the current window to determine the which scancodes to send
-win: Send the virtual key and its scan code in the events to work with programs that only look at one of the two
+- win: Respect the language of the current window to determine the which scancodes to send
+- win: Send the virtual key and its scan code in the events to work with programs that only look at one of the two
+- macOS: Moving the mouse no longer breaks simulating input
 
 # 0.2.1
 ## Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,6 +451,11 @@ pub struct Settings {
     /// Open a prompt to ask the user for the permission to simulate input if
     /// they are missing. This only works on macOS. The default is true.
     pub open_prompt_to_get_permissions: bool,
+    /// The simulated input is independent from the pressed keys on the
+    /// physical keyboard. This only works on macOS.
+    /// The default is true. If the Shift key for example is pressed,
+    /// following simulated input will not be capitalized.
+    pub independent_of_keyboard_state: bool,
 }
 
 impl Default for Settings {
@@ -465,6 +470,7 @@ impl Default for Settings {
             event_source_user_data: None,
             release_keys_when_dropped: true,
             open_prompt_to_get_permissions: true,
+            independent_of_keyboard_state: true,
         }
     }
 }

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -488,6 +488,7 @@ impl Enigo {
             release_keys_when_dropped,
             event_source_user_data,
             open_prompt_to_get_permissions,
+            independent_of_keyboard_state,
             ..
         } = settings;
 
@@ -504,8 +505,12 @@ impl Enigo {
         // Returns the double click interval (https://developer.apple.com/documentation/appkit/nsevent/1528384-doubleclickinterval). This is a TimeInterval which is a f64 of the number of seconds
         let double_click_delay = double_click_delay.mul_f64(double_click_delay_setting);
 
-        let Ok(event_source) = CGEventSource::new(CGEventSourceStateID::CombinedSessionState)
-        else {
+        let event_source_state = if *independent_of_keyboard_state {
+            CGEventSourceStateID::Private
+        } else {
+            CGEventSourceStateID::CombinedSessionState
+        };
+        let Ok(event_source) = CGEventSource::new(event_source_state) else {
             return Err(NewConError::EstablishCon("failed creating event source"));
         };
 


### PR DESCRIPTION
Previously the state of the physical keyboard and the mouse effected the result of the simulated input. If the `Command` key was held on the physical keyboard, the `text()` function no longer worked. If the mouse was moved, Command+a no longer worked. By default the physical state and the state of the simulated input are now independent, but this behavior can be changed with the `Settings` struct (`independent_of_keyboard_state`). Fixes https://github.com/enigo-rs/enigo/issues/297
Fixes https://github.com/enigo-rs/enigo/issues/201