### PR TITLE
macos: Fix regression with special keys such as VolumeUp

### DIFF
--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -577,14 +577,12 @@ impl Enigo {
     }
 
     fn special_keys(&self, code: isize, direction: Direction) -> InputResult<()> {
-        let flags = NSEventModifierFlags::NSEventModifierFlagCapsLock
-            .union(NSEventModifierFlags::NSEventModifierFlagOption);
         if direction == Direction::Press || direction == Direction::Click {
             let event = unsafe {
                 NSEvent::otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2(
                 NSEventType::SystemDefined, // 14
                 NSPoint::ZERO,
-                flags,
+                NSEventModifierFlags::empty(),
                 0.0,
                 0,
                 None,
@@ -609,12 +607,11 @@ impl Enigo {
         }
 
         if direction == Direction::Release || direction == Direction::Click {
-            let flags = flags.union(NSEventModifierFlags::NSEventModifierFlagShift);
             let event = unsafe {
                 NSEvent::otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2(
                     NSEventType::SystemDefined, // 14
                 NSPoint::ZERO,
-                flags,
+                NSEventModifierFlags::empty(),
                 0.0,
                 0,
                 None,


### PR DESCRIPTION
The refactoring broke the special keys such as `VolumeUp` and `BrightnessUp`. Instead of doing what they are supposed to, somehow they managed to pop open the settings on the Sound/Display page. This could come in handy, but was not what the user wants. When fixing it, I noticed that the `EventModifierFlags` did not make any logical sense so I tried it with empty flags. That also works