### PR TITLE
linux: libei: Improve the typing speed dramatically

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
 - macOS: Switched keycodes of `Key::Launchpad` and `Key::MissionControl`
 - macOS: `CapsLock` works ([#163](https://github.com/enigo-rs/enigo/issues/163))
 - macOS: Moving the mouse works also if it is the only function ([#182](https://github.com/enigo-rs/enigo/issues/182))
+- linux: libei: Typing is much faster now
 
 # 0.2.1
 ## Changed


### PR DESCRIPTION
Previously the update function tried 50 times to get pending events and handle them even if there previously also was no event to handle. We now check for pending events and if there were none twice in a row, we assume we are done updating