### PR TITLE
win: Added setting to chose if the mouse speed and acceleration should influence relative mouse moves

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 - macOS: Fallback to ASCII-capable keyboard layout for handling non-standard input sources
 - macOS: Check if the application has the necessary permissions. If they are missing, `enigo` will ask the user to grant them. You can change this default behavior with the `Settings` when constructing an `Enigo` struct.
 - all: Added `Token::Location` and `Token::MainDisplay` mostly for debugging purposes. They allow you to check if your expectations are correct
+- win: Added a setting to take the mouse speed and acceleration level into account for relative mouse movement or reliably move the mouse to the expected location.
 
 ## Fixed
 - macOS: No more sleeps!! (Only when the `Enigo` struct is dropped) ([#105](https://github.com/enigo-rs/enigo/issues/105))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,6 +433,7 @@ impl Error for NewConError {}
 
 /// Settings for creating the Enigo struct and it's behavior
 #[allow(dead_code)] // It is not dead code on other platforms
+#[allow(clippy::struct_excessive_bools)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Settings {
@@ -460,6 +461,13 @@ pub struct Settings {
     /// The default is true. If the Shift key for example is pressed,
     /// following simulated input will not be capitalized.
     pub independent_of_keyboard_state: bool,
+    /// If this is set to true, the relative mouse motion will be subject to the
+    /// settings for mouse speed and acceleration level. An end user sets
+    /// these values using the Mouse application in Control Panel. An
+    /// application obtains and sets these values with the
+    /// `windows::Win32::UI::WindowsAndMessaging::SystemParametersInfoA`
+    /// function. The default value is false.
+    pub windows_subject_to_mouse_speed_and_acceleration_level: bool,
 }
 
 impl Default for Settings {
@@ -474,6 +482,7 @@ impl Default for Settings {
             release_keys_when_dropped: true,
             open_prompt_to_get_permissions: true,
             independent_of_keyboard_state: true,
+            windows_subject_to_mouse_speed_and_acceleration_level: false,
         }
     }
 }


### PR DESCRIPTION
Relative mouse moves are subject to the mouse speed and acceleration levels on Windows. This leads to the mouse being at an unexpected coordinate afterwards. On other platforms this is also not the case. For some use cases it might be desirable, so I added a setting for the user to chose the behavior. 

By default we calculate the resulting location of a relative mouse move and do an absolute move. Only if the user of the library sets `windows_subject_to_mouse_speed_and_acceleration_level` to true do the mouse speed and acceleration have an effect. I added a quote from the documentation how the location is calculated then. That should help for writing test cases.

Fix https://github.com/enigo-rs/enigo/issues/91