### PR TITLE
Bump MSRV to 1.82

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.80.0"
+          - "1.82.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/failing_tests.yml
+++ b/.github/workflows/failing_tests.yml
@@ -22,7 +22,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.80.0"
+          - "1.82.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.80.0"
+          - "1.82.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.80.0"
+          - "1.82.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,11 @@
 # Unreleased
 ## Changed
+- Rust: MSRV is 1.82
+
 ## Added
+
 ## Removed
+
 ## Fixed
 
 # 0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Dustin Bensing <dustin.bensing@googlemail.com>",
 ]
 edition = "2021"
-rust-version = "1.75" # The CI already runs on 1.80 because the tests needed it
+rust-version = "1.82"
 description = "Cross-platform (Linux, Windows, macOS & BSD) library to simulate keyboard and mouse events"
 documentation = "https://docs.rs/enigo/"
 homepage = "https://github.com/enigo-rs/enigo"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Docs](https://docs.rs/enigo/badge.svg)](https://docs.rs/enigo)
 [![Dependency status](https://deps.rs/repo/github/enigo-rs/enigo/status.svg)](https://deps.rs/repo/github/enigo-rs/enigo)
 
-![Rust version](https://img.shields.io/badge/rust--version-1.75+-brightgreen.svg)
+![Rust version](https://img.shields.io/badge/rust--version-1.82+-brightgreen.svg)
 [![Crates.io](https://img.shields.io/crates/v/enigo.svg)](https://crates.io/crates/enigo)
 
 # enigo


### PR DESCRIPTION
The tests already need 1.80 and one of the PRs I am preparing needs 1.82. 1.82 was released 17 October, 2024. A new version of enigo will probably not be released within the next few weeks/months so by then 1.82 will probably be a few months old