### PR TITLE
all: Don't panic if a logger was already initialized

### DIFF
--- a/examples/key.rs
+++ b/examples/key.rs
@@ -6,7 +6,7 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    env_logger::init();
+    env_logger::try_init().ok();
     thread::sleep(Duration::from_secs(2));
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
 

--- a/examples/keyboard.rs
+++ b/examples/keyboard.rs
@@ -6,7 +6,7 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    env_logger::init();
+    env_logger::try_init().ok();
     thread::sleep(Duration::from_secs(2));
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
 

--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -3,7 +3,7 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    env_logger::init();
+    env_logger::try_init().ok();
     thread::sleep(Duration::from_secs(4));
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
 

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -9,7 +9,7 @@ use std::thread;
 use std::time::Duration;
 
 fn main() {
-    env_logger::init();
+    env_logger::try_init().ok();
     let wait_time = Duration::from_secs(2);
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
 

--- a/examples/platform_specific.rs
+++ b/examples/platform_specific.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 // This example will do different things depending on the platform
 fn main() {
-    env_logger::init();
+    env_logger::try_init().ok();
     thread::sleep(Duration::from_secs(2));
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
 

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -5,7 +5,7 @@ use enigo::{
 use std::{thread, time::Duration};
 
 fn main() {
-    env_logger::init();
+    env_logger::try_init().ok();
     thread::sleep(Duration::from_secs(2));
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
 

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 fn main() {
-    env_logger::init();
+    env_logger::try_init().ok();
     thread::sleep(Duration::from_secs(2));
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
 

--- a/tests/common/enigo_test.rs
+++ b/tests/common/enigo_test.rs
@@ -23,7 +23,7 @@ pub struct EnigoTest {
 
 impl EnigoTest {
     pub fn new(settings: &Settings) -> Self {
-        env_logger::init();
+        env_logger::try_init().ok();
         EnigoTest::start_timeout_thread();
         let enigo = Enigo::new(settings).unwrap();
         let _ = &*super::browser::BROWSER_INSTANCE; // Launch Firefox


### PR DESCRIPTION
Calling env_logger::init() will fail if a logger already was initialized. This likely happens when tests are ran. We now try to initialize it but don't panic if it was already initialized.