### PR TITLE
[macOS] Add Mouse special key(`Back`, `Forward`) on `macOS` by button number

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 - Rust: MSRV is 1.82
 
 ## Added
+- macOS: Add to support Mouse special key(Back, Forward)
 
 ## Removed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,13 +108,11 @@ pub enum Button {
     #[cfg_attr(feature = "serde", serde(alias = "r"))]
     Right,
     /// 4th mouse button. Typically performs the same function as `Browser_Back`
-    #[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
     #[cfg_attr(feature = "serde", serde(alias = "B"))]
     #[cfg_attr(feature = "serde", serde(alias = "b"))]
     Back,
     /// 5th mouse button. Typically performs the same function as
     /// `Browser_Forward`
-    #[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
     #[cfg_attr(feature = "serde", serde(alias = "F"))]
     #[cfg_attr(feature = "serde", serde(alias = "f"))]
     Forward,


### PR DESCRIPTION
Currently, `macOS` does not support input for mouse special keys.(`Back`, `Forward`)

To add this functionality, if the special input is of type `OtherMouseUp` / `OtherMouseDown` on `macOS`, send the mouse's number along with it so that special keystrokes can be supported.

This is a very simple way to do this.

Increase the number in `last_moues_click` by 2, from `7` to `9`, since the total number of keys supported on `macOS` has increased.

> It would be nice to specify that `last_mouse_click` should be incremented as the number of supported mouse keys increases, or to make it consistent via tests or types.
> I realized later that the reason the test didn't pass in this fix was because of the "index out of bounds" of `last_mouse_click`