### PR TITLE
linux: Replaces NO_SYMBOL with upsteam const

### DIFF
--- a/src/linux/keymap.rs
+++ b/src/linux/keymap.rs
@@ -9,10 +9,6 @@ pub(super) use xkeysym::{KeyCode, Keysym};
 use crate::keycodes::ModifierBitflag;
 use crate::{Direction, InputError, InputResult, Key};
 
-/// The "empty" keyboard symbol.
-// TODO: Replace it with the NoSymbol from xkeysym, once a new version was
-// published
-pub const NO_SYMBOL: Keysym = Keysym::new(0);
 #[cfg(feature = "x11rb")]
 const DEFAULT_DELAY: u32 = 12;
 
@@ -203,7 +199,7 @@ where
         keycode: Keycode,
     ) -> InputResult<()> {
         trace!("trying to unmap keysym {:?}", keysym);
-        if c.bind_key(keycode, NO_SYMBOL).is_err() {
+        if c.bind_key(keycode, Keysym::NoSymbol).is_err() {
             return Err(InputError::Unmapping(format!("{keysym:?}")));
         };
         self.needs_regeneration = true;

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -14,7 +14,7 @@ use x11rb::{
     wrapper::ConnectionExt as _,
 };
 
-use super::keymap::{Bind, KeyMap, Keysym, NO_SYMBOL};
+use super::keymap::{Bind, KeyMap, Keysym};
 use crate::{
     keycodes::Modifier, Axis, Button, Coordinate, Direction, InputError, InputResult, Key,
     Keyboard, Mouse, NewConError,
@@ -146,7 +146,7 @@ impl Con {
                 trace!("{kc}:  {syms_name:?}");
             }
 
-            if syms.iter().all(|&s| s == NO_SYMBOL.raw()) {
+            if syms.iter().all(|&s| s == Keysym::NoSymbol.raw()) {
                 unused_keycodes.push_back(kc);
             }
         }
@@ -220,7 +220,7 @@ impl Drop for Con {
         // changes
         debug!("x11rb connection was dropped");
         for &keycode in self.keymap.additionally_mapped.values() {
-            match self.connection.bind_key(keycode, NO_SYMBOL) {
+            match self.connection.bind_key(keycode, Keysym::NoSymbol) {
                 Ok(()) => debug!("unmapped keycode {keycode:?}"),
                 Err(e) => error!("unable to unmap keycode {keycode:?}. {e:?}"),
             };


### PR DESCRIPTION
Minor cleanup. I upstreamed `NoSymbol` and forgot to use it instead of our locally defined struct.