### PR TITLE
win: Added helper function to tell Windows to respect the users scaling settings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ## Added
 - macOS: Add to support Mouse special key(Back, Forward)
+- win: Helper function to tell Windows to respect the users scaling settings `set_dpi_awareness`. Read the docs before using it
 
 ## Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ windows = { version = "0.58", features = [
     "Win32_UI_TextServices",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_HiDpi",
 ] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -10,6 +10,13 @@ use std::time::Duration;
 
 fn main() {
     env_logger::try_init().ok();
+
+    #[cfg(target_os = "windows")]
+    // This is needed on Windows if you want the application to respect the users scaling settings.
+    // Please look at the documentation of the function to see better ways to achive this and
+    // important gotchas
+    enigo::set_dpi_awareness().unwrap();
+
     let wait_time = Duration::from_secs(2);
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,8 @@ mod platform;
 pub use platform::Enigo;
 
 #[cfg(target_os = "windows")]
+pub use platform::set_dpi_awareness;
+#[cfg(target_os = "windows")]
 pub use platform::EXT;
 
 mod keycodes;

--- a/src/win/mod.rs
+++ b/src/win/mod.rs
@@ -1,2 +1,2 @@
 mod win_impl;
-pub use win_impl::{Enigo, EXT};
+pub use win_impl::{set_dpi_awareness, Enigo, EXT};

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -531,6 +531,31 @@ impl Enigo {
     }
 }
 
+/// Sets the current process to a specified dots per inch (dpi) awareness
+/// context [see official documentation](https://learn.microsoft.com/en-us/windows/win32/api/shellscalingapi/nf-shellscalingapi-setprocessdpiawareness)
+/// If you want your applications to respect the users scaling, you need to set
+/// this. Otherwise the mouse coordinates and screen dimensions will be off.
+///
+/// It is recommended that you set the process-default DPI awareness via
+/// application manifest, not an API call. See [Setting the default DPI awareness for a process](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setprocessdpiawarenesscontext) for more information. Setting the process-default DPI
+/// awareness via API call can lead to unexpected application behavior.
+/// It also needs to be set before any APIs are used that depend on the DPI and
+/// before a UI is created.
+/// Enigo is a library and should not set this, because
+/// it will lead to unexpected scaling of the application. Only use it for
+/// examples or if you know about the consequences
+///
+/// # Errors
+/// An error is thrown if the default API awareness mode for the process has
+/// already been set (via a previous API call or within the application
+/// manifest)
+pub fn set_dpi_awareness() -> Result<(), ()> {
+    use windows::Win32::UI::HiDpi::SetProcessDpiAwareness;
+    use windows::Win32::UI::HiDpi::PROCESS_PER_MONITOR_DPI_AWARE;
+
+    unsafe { SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE) }.map_err(|_| ())
+}
+
 impl Drop for Enigo {
     // Release the held keys before the connection is dropped
     fn drop(&mut self) {


### PR DESCRIPTION
A flag needs to get set so that Windows knows the application is aware of the DPI. This needs to be done before any DPI related APIs are used or the UI gets started. Please look at the official documentation or the docs of the newly added helper function for more details and important gotchas.

 Fixes https://github.com/enigo-rs/enigo/issues/370