### PR TITLE
chore: Update `objc2` v0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,9 +56,17 @@ windows = { version = "0.59", features = [
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"
 core-graphics = { version = "0.24", features = ["highsierra"] }
-objc2 = { version = "0.5", features = ["relax-void-encoding"] }
-objc2-app-kit = { version = "0.2", features = ["NSEvent", "NSGraphicsContext"] }
-objc2-foundation = { version = "0.2", features = ["NSGeometry"] }
+objc2 = { version = "0.6", features = ["relax-void-encoding"] }
+objc2-app-kit = { version = "0.3", default-features = false, features = [
+    "std",
+    "NSEvent",
+    "NSGraphicsContext",
+] }
+objc2-foundation = { version = "0.3", default-features = false, features = [
+    "std",
+    "objc2-core-foundation",
+    "NSGeometry",
+] }
 foreign-types-shared = "0.3"
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]


### PR DESCRIPTION
The new `objc2` framework crates have a bunch of default features enabled, see https://github.com/madsmtm/objc2/issues/627, so this PR disables them, so that your compile times down blow up.

Replaces https://github.com/enigo-rs/enigo/pull/380.
Replaces https://github.com/enigo-rs/enigo/pull/381.