### PR TITLE
linux: Wayland: fix input_method serial number

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ## Removed
 
 ## Fixed
+- linux: wayland: Fix the serial number of input_method events
 
 # 0.3.0
 ## Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ wayland = [
     "dep:wayland-client",
     "dep:wayland-protocols-misc",
     "dep:wayland-protocols-wlr",
-    "dep:wayland-protocols-plasma",
     "dep:tempfile",
 ]
 xdo = []
@@ -79,9 +78,6 @@ wayland-protocols-misc = { version = "0.3", features = [
     "client",
 ], optional = true }
 wayland-protocols-wlr = { version = "0.3", features = [
-    "client",
-], optional = true }
-wayland-protocols-plasma = { version = "0.3", features = [
     "client",
 ], optional = true }
 wayland-client = { version = "0.31", optional = true }

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -15,7 +15,6 @@ use wayland_protocols_misc::{
     zwp_input_method_v2::client::{zwp_input_method_manager_v2, zwp_input_method_v2},
     zwp_virtual_keyboard_v1::client::{zwp_virtual_keyboard_manager_v1, zwp_virtual_keyboard_v1},
 };
-use wayland_protocols_plasma::fake_input::client::org_kde_kwin_fake_input;
 use wayland_protocols_wlr::virtual_pointer::v1::client::{
     zwlr_virtual_pointer_manager_v1, zwlr_virtual_pointer_v1,
 };
@@ -156,14 +155,6 @@ impl Con {
             .pointer_manager
             .as_ref()
             .map(|vp_mgr| vp_mgr.create_virtual_pointer(self.state.seat.as_ref(), &qh, ()));
-
-        // Try to authenticate for the KDE Fake Input protocol
-        // TODO: Get this protocol to work
-        if let Some(kde_input) = &self.state.kde_input {
-            let application = "enigo".to_string();
-            let reason = "enter keycodes or move the mouse".to_string();
-            kde_input.authenticate(application, reason);
-        }
 
         trace!(
             "protocols available\nvirtual_keyboard: {}\ninput_method: {}\nvirtual_pointer: {}",
@@ -323,7 +314,6 @@ struct WaylandState {
     keyboard_manager: Option<zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1>,
     im_manager: Option<zwp_input_method_manager_v2::ZwpInputMethodManagerV2>,
     pointer_manager: Option<zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1>,
-    kde_input: Option<org_kde_kwin_fake_input::OrgKdeKwinFakeInput>,
     seat: Option<wl_seat::WlSeat>,
     /*  output: Option<wl_output::WlOutput>,
     width: i32,
@@ -336,7 +326,6 @@ impl WaylandState {
             keyboard_manager: None,
             im_manager: None,
             pointer_manager: None,
-            kde_input: None,
             seat: None,
             /*  output: None,
             width: 0,
@@ -401,17 +390,6 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                     );
                     state.pointer_manager = Some(manager);
                 }
-                "org_kde_kwin_fake_input" => {
-                    debug!("FAKE_INPUT AVAILABLE!");
-                    let kde_input = registry
-                        .bind::<org_kde_kwin_fake_input::OrgKdeKwinFakeInput, _, _>(
-                            name,
-                            1,
-                            qh,
-                            (),
-                        );
-                    state.kde_input = Some(kde_input);
-                }
                 s => {
                     trace!("i: {}", s);
                 }
@@ -468,20 +446,6 @@ impl Dispatch<zwp_input_method_v2::ZwpInputMethodV2, ()> for WaylandState {
         _qh: &QueueHandle<Self>,
     ) {
         warn!("Got a input method event {:?}", event);
-    }
-}
-impl Dispatch<org_kde_kwin_fake_input::OrgKdeKwinFakeInput, ()> for WaylandState {
-    fn event(
-        _state: &mut Self,
-        _vk: &org_kde_kwin_fake_input::OrgKdeKwinFakeInput,
-        event: org_kde_kwin_fake_input::Event,
-        (): &(),
-        _: &Connection,
-        _qh: &QueueHandle<Self>,
-    ) {
-        // This should never happen, as there are no events specified for this
-        // in the protocol
-        warn!("Got a plasma fake input event {:?}", event);
     }
 }
 

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -95,9 +95,9 @@ impl Con {
 
         // Setup WaylandState and dispatch events
         let mut state = WaylandState::new();
-        if event_queue.roundtrip(&mut state).is_err() {
-            return Err(NewConError::EstablishCon("wayland roundtrip not possible"));
-        };
+        event_queue
+            .roundtrip(&mut state)
+            .map_err(|_| NewConError::EstablishCon("Wayland roundtrip failed"))?;
 
         let (virtual_keyboard, input_method, virtual_pointer) = (None, None, None);
 
@@ -195,17 +195,17 @@ impl Con {
                 trace!("vk.key({time}, {keycode}, 1)");
                 vk.key(time, keycode, 1);
                 // TODO: Change to flush()
-                if self.event_queue.roundtrip(&mut self.state).is_err() {
-                    return Err(InputError::Simulate("The roundtrip on Wayland failed"));
-                }
+                self.event_queue
+                    .roundtrip(&mut self.state)
+                    .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))?;
             }
             if direction == Direction::Release || direction == Direction::Click {
                 trace!("vk.key({time}, {keycode}, 0)");
                 vk.key(time, keycode, 0);
                 // TODO: Change to flush()
-                if self.event_queue.roundtrip(&mut self.state).is_err() {
-                    return Err(InputError::Simulate("The roundtrip on Wayland failed"));
-                }
+                self.event_queue
+                    .roundtrip(&mut self.state)
+                    .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))?;
             }
             return Ok(());
         }
@@ -220,9 +220,10 @@ impl Con {
             trace!("vk.modifiers({modifiers}, 0, 0, 0)");
             vk.modifiers(modifiers, 0, 0, 0);
             // TODO: Change to flush()
-            if self.event_queue.roundtrip(&mut self.state).is_err() {
-                return Err(InputError::Simulate("The roundtrip on Wayland failed"));
-            }
+            self.event_queue
+                .roundtrip(&mut self.state)
+                .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))?;
+
             return Ok(());
         }
         Err(InputError::Simulate("no way to enter modifier"))
@@ -248,9 +249,9 @@ impl Con {
                 trace!("update wayland keymap");
                 vk.keymap(1, self.keymap.file.as_ref().unwrap().as_fd(), keymap_size);
                 // TODO: Change to flush()
-                if self.event_queue.roundtrip(&mut self.state).is_err() {
-                    return Err(InputError::Simulate("The roundtrip on Wayland failed"));
-                }
+                self.event_queue
+                    .roundtrip(&mut self.state)
+                    .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))?;
             }
             return Ok(());
         }
@@ -547,9 +548,10 @@ impl Keyboard for Con {
             im.commit(*serial);
             *serial = serial.wrapping_add(1);
             // TODO: Change to flush()
-            if self.event_queue.roundtrip(&mut self.state).is_err() {
-                return Err(InputError::Simulate("The roundtrip on Wayland failed"));
-            }
+            self.event_queue
+                .roundtrip(&mut self.state)
+                .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))?;
+
             return Ok(Some(()));
         }
         Ok(None)
@@ -630,10 +632,10 @@ impl Mouse for Con {
             }
         }
         // TODO: Change to flush()
-        match self.event_queue.roundtrip(&mut self.state) {
-            Ok(_) => Ok(()),
-            Err(_) => Err(InputError::Simulate("The roundtrip on Wayland failed")),
-        }
+        self.event_queue
+            .roundtrip(&mut self.state)
+            .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))
+            .map(|_| ())
     }
 
     fn move_mouse(&mut self, x: i32, y: i32, coordinate: Coordinate) -> InputResult<()> {
@@ -668,10 +670,10 @@ impl Mouse for Con {
             vp.frame(); // TODO: Check if this is needed
         }
         // TODO: Change to flush()
-        match self.event_queue.roundtrip(&mut self.state) {
-            Ok(_) => Ok(()),
-            Err(_) => Err(InputError::Simulate("The roundtrip on Wayland failed")),
-        }
+        self.event_queue
+            .roundtrip(&mut self.state)
+            .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))
+            .map(|_| ())
     }
 
     fn scroll(&mut self, length: i32, axis: Axis) -> InputResult<()> {
@@ -688,10 +690,10 @@ impl Mouse for Con {
             vp.frame(); // TODO: Check if this is needed
         }
         // TODO: Change to flush()
-        match self.event_queue.roundtrip(&mut self.state) {
-            Ok(_) => Ok(()),
-            Err(_) => Err(InputError::Simulate("The roundtrip on Wayland failed")),
-        }
+        self.event_queue
+            .roundtrip(&mut self.state)
+            .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))
+            .map(|_| ())
     }
 
     fn main_display(&self) -> InputResult<(i32, i32)> {

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -67,7 +67,7 @@ impl Con {
         display.get_registry(&qh, ());
 
         // Setup WaylandState and dispatch events
-        let mut state = WaylandState::new();
+        let mut state = WaylandState::default();
         event_queue
             .roundtrip(&mut state)
             .map_err(|_| NewConError::EstablishCon("Wayland roundtrip failed"))?;
@@ -322,6 +322,7 @@ impl Drop for Con {
     }
 }
 
+#[derive(Clone, Debug, Default)]
 /// Stores the manager for the various protocols
 struct WaylandState {
     keyboard_manager: Option<zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1>,
@@ -333,19 +334,7 @@ struct WaylandState {
     height: i32,*/
 }
 
-impl WaylandState {
-    fn new() -> Self {
-        Self {
-            keyboard_manager: None,
-            im_manager: None,
-            pointer_manager: None,
-            seat: None,
-            /*  output: None,
-            width: 0,
-            height: 0,*/
-        }
-    }
-}
+impl WaylandState {}
 
 impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
     fn event(


### PR DESCRIPTION
Fixing https://github.com/enigo-rs/enigo/issues/356 will take some more time. For now I cherry-picked the commits from MR https://github.com/enigo-rs/enigo/pull/368 that already improve the readability of the code and to fix a bug with the serial number of the input_method events on Wayland