### PR TITLE
linux: wayland: Fix order of wayland messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 ## Fixed
 - linux: wayland: Fix the serial number of input_method events
 - linux: wayland: Correct whitespace and nullbyte at the end of the keymap
+- linux: wayland: Send messages in the correct order and make sure Wayland objects are created before they are used
 
 # 0.3.0
 ## Changed

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -10,7 +10,12 @@ use std::{
 
 use log::{debug, error, trace, warn};
 use wayland_client::{
-    protocol::{wl_pointer, wl_registry, wl_seat},
+    protocol::{
+        wl_keyboard::{self, WlKeyboard},
+        wl_pointer::{self, WlPointer},
+        wl_registry,
+        wl_seat::{self, Capability},
+    },
     Connection, Dispatch, EventQueue, QueueHandle,
 };
 use wayland_protocols_misc::{
@@ -66,9 +71,9 @@ impl Con {
 
         // Start registry
         let display = connection.display();
-        display.get_registry(&qh, ());
+        let registry = display.get_registry(&qh, ());
 
-        // Setup WaylandState and dispatch events
+        // Setup WaylandState and store the globals in it
         let mut state = WaylandState::default();
         event_queue
             .roundtrip(&mut state)
@@ -92,6 +97,8 @@ impl Con {
             virtual_pointer: None,
             base_time: Instant::now(),
         };
+
+        connection.bind_globals(&registry)?;
 
         connection.init_protocols()?;
 
@@ -126,25 +133,122 @@ impl Con {
         })
     }
 
+    fn bind_globals(&mut self, registry: &wl_registry::WlRegistry) -> Result<(), NewConError> {
+        let qh = self.event_queue.handle();
+
+        // Bind to wl_seat if it exists
+        // MUST be done before doing any bindings relevant to the input_method
+        // protocol, otherwise e.g. labwc crashes
+        let &(name, version) = self
+            .state
+            .globals
+            .get("wl_seat")
+            .ok_or(NewConError::EstablishCon("No seat available"))?;
+        let seat = registry.bind::<wl_seat::WlSeat, _, _>(name, version.min(1), &qh, ());
+
+        self.event_queue
+            .flush()
+            .map_err(|_| NewConError::EstablishCon("Flushing Wayland queue failed"))?;
+        self.state.seat = Some(seat);
+
+        // Wait for compositor to handle the request and send back the capabilities of
+        // the seat
+        // The WlPointer and/or WlKeyboard get created now if the seat has the
+        // capabilities for it
+        debug!("waiting for response of request to bind to seat");
+        self.event_queue
+            .blocking_dispatch(&mut self.state)
+            .map_err(|_| NewConError::EstablishCon("Wayland blocking dispatch failed"))?;
+
+        // Send the events to the compositor to handle them
+        self.event_queue
+            .flush()
+            .map_err(|_| NewConError::EstablishCon("Flushing Wayland queue failed"))?;
+
+        // Wait for compositor to create the WlPointer and WlKeyboard and get the keymap
+        // of the WlKeyboard
+        debug!("asked to create keyboard and pointer");
+        self.event_queue
+            .blocking_dispatch(&mut self.state)
+            .map_err(|_| NewConError::EstablishCon("Wayland blocking dispatch failed"))?;
+
+        // Ask compositor to create VirtualKeyboardManager
+        if let Some(&(name, version)) = self.state.globals.get("zwp_virtual_keyboard_manager_v1") {
+            let manager = registry
+                .bind::<zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1, _, _>(
+                    name,
+                    version.min(1),
+                    &qh,
+                    (),
+                );
+            self.event_queue
+                .flush()
+                .map_err(|_| NewConError::EstablishCon("Flushing Wayland queue failed"))?;
+            self.state.keyboard_manager = Some(manager);
+        }
+
+        // Ask compositor to create InputMethodManager
+        if let Some(&(name, version)) = self.state.globals.get("zwp_input_method_manager_v2") {
+            let manager = registry
+                .bind::<zwp_input_method_manager_v2::ZwpInputMethodManagerV2, _, _>(
+                    name,
+                    version.min(1),
+                    &qh,
+                    (),
+                );
+            self.event_queue
+                .flush()
+                .map_err(|_| NewConError::EstablishCon("Flushing Wayland queue failed"))?;
+            self.state.im_manager = Some(manager);
+        }
+
+        // Ask compositor to create VirtualPointerManager
+        if let Some(&(name, version)) = self.state.globals.get("zwlr_virtual_pointer_manager_v1") {
+            let manager = registry
+                .bind::<zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1, _, _>(
+                    name,
+                    version.min(1),
+                    &qh,
+                    (),
+                );
+            self.event_queue
+                .flush()
+                .map_err(|_| NewConError::EstablishCon("Flushing Wayland queue failed"))?;
+            self.state.pointer_manager = Some(manager);
+        }
+
+        Ok(())
+    }
+
     /// Try to set up all the protocols. An error is returned, if no protocol is
     /// available
     fn init_protocols(&mut self) -> Result<(), NewConError> {
         let qh = self.event_queue.handle();
 
-        if let Some(seat) = self.state.seat.as_ref() {
-            // Setup virtual keyboard
-            self.virtual_keyboard = self
-                .state
-                .keyboard_manager
-                .as_ref()
-                .map(|vk_mgr| vk_mgr.create_virtual_keyboard(seat, &qh, ()));
+        if self.state.seat.is_some() {
             // Setup input method
-            self.input_method = self
-                .state
-                .im_manager
-                .as_ref()
-                .map(|im_mgr| im_mgr.get_input_method(seat, &qh, ()));
-        };
+            self.input_method =
+                self.state.im_manager.as_ref().map(|im_mgr| {
+                    im_mgr.get_input_method(self.state.seat.as_ref().unwrap(), &qh, ())
+                });
+            // Wait for Activate response if the input_method was created
+            if self.input_method.is_some() {
+                self.event_queue
+                    .blocking_dispatch(&mut self.state)
+                    .map_err(|_| NewConError::EstablishCon("Wayland blocking dispatch failed"))?;
+            }
+
+            // Setup virtual keyboard
+            self.virtual_keyboard = self.state.keyboard_manager.as_ref().map(|vk_mgr| {
+                vk_mgr.create_virtual_keyboard(self.state.seat.as_ref().unwrap(), &qh, ())
+            });
+            // Wait for KeyMap response if virtual_keyboard was created
+            if self.virtual_keyboard.is_some() {
+                self.event_queue
+                    .blocking_dispatch(&mut self.state)
+                    .map_err(|_| NewConError::EstablishCon("Wayland blocking dispatch failed"))?;
+            }
+        }
 
         // Setup virtual pointer
         self.virtual_pointer = self
@@ -152,8 +256,15 @@ impl Con {
             .pointer_manager
             .as_ref()
             .map(|vp_mgr| vp_mgr.create_virtual_pointer(self.state.seat.as_ref(), &qh, ()));
+        if self.virtual_pointer.is_some() {
+            self.event_queue
+                .flush()
+                .map_err(|_| NewConError::EstablishCon("Flushing Wayland queue failed"))?;
+        }
 
-        trace!(
+        debug!("create virtual keyboard is done");
+
+        debug!(
             "protocols available\nvirtual_keyboard: {}\ninput_method: {}\nvirtual_pointer: {}",
             self.virtual_keyboard.is_some(),
             self.input_method.is_some(),
@@ -194,18 +305,16 @@ impl Con {
         if direction == Direction::Press || direction == Direction::Click {
             trace!("vk.key({time}, {keycode}, 1)");
             vk.key(time, keycode, 1);
-            // TODO: Change to flush()
             self.event_queue
-                .roundtrip(&mut self.state)
-                .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))?;
+                .flush()
+                .map_err(|_| InputError::Simulate("Flushing Wayland queue failed"))?;
         }
         if direction == Direction::Release || direction == Direction::Click {
             trace!("vk.key({time}, {keycode}, 0)");
             vk.key(time, keycode, 0);
-            // TODO: Change to flush()
             self.event_queue
-                .roundtrip(&mut self.state)
-                .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))?;
+                .flush()
+                .map_err(|_| InputError::Simulate("Flushing Wayland queue failed"))?;
         }
         Ok(())
     }
@@ -228,11 +337,9 @@ impl Con {
         // Send the modifier event
         vk.modifiers(modifiers, 0, 0, 0);
 
-        // TODO: Change to flush()
-        // Perform a roundtrip to send the event
         self.event_queue
-            .roundtrip(&mut self.state)
-            .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))?;
+            .flush()
+            .map_err(|_| InputError::Simulate("Flushing Wayland queue failed"))?;
 
         Ok(())
     }
@@ -266,10 +373,10 @@ impl Con {
         let keymap_file = self.keymap.file.as_ref().unwrap(); // Safe here, assuming file is always present
         vk.keymap(1, keymap_file.as_fd(), size);
 
-        // TODO: Change to flush()
+        debug!("wait for response after keymap call");
         self.event_queue
-            .roundtrip(&mut self.state)
-            .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))?;
+            .blocking_dispatch(&mut self.state)
+            .map_err(|_| InputError::Simulate("Wayland blocking_dispatch failed"))?;
 
         Ok(())
     }
@@ -327,76 +434,45 @@ impl Drop for Con {
 #[derive(Clone, Debug, Default)]
 /// Stores the manager for the various protocols
 struct WaylandState {
+    // Map of interface name -> (global name, version)
+    globals: std::collections::HashMap<String, (u32, u32)>,
     keyboard_manager: Option<zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1>,
     im_manager: Option<zwp_input_method_manager_v2::ZwpInputMethodManagerV2>,
     im_serial: Wrapping<u32>,
     pointer_manager: Option<zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1>,
     seat: Option<wl_seat::WlSeat>,
+    seat_keyboard: Option<WlKeyboard>,
+    seat_pointer: Option<WlPointer>,
     /*  output: Option<wl_output::WlOutput>,
     width: i32,
     height: i32,*/
 }
 
-impl WaylandState {}
-
 impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
     fn event(
         state: &mut Self,
-        registry: &wl_registry::WlRegistry,
+        _: &wl_registry::WlRegistry,
         event: wl_registry::Event,
         (): &(),
         _: &Connection,
-        qh: &QueueHandle<Self>,
+        _: &QueueHandle<Self>,
     ) {
         // When receiving events from the wl_registry, we are only interested in the
-        // `global` event, which signals a new available global.
+        // `global` event, which signals a new available global and then store it to
+        // later bind to them
         if let wl_registry::Event::Global {
-            name, interface, ..
+            name,
+            interface,
+            version,
         } = event
         {
-            match &interface[..] {
-                "wl_seat" => {
-                    let seat = registry.bind::<wl_seat::WlSeat, _, _>(name, 1, qh, ());
-                    state.seat = Some(seat);
-                }
-                /*"wl_output" => {
-                    let output = registry.bind::<wl_output::WlOutput, _, _>(name, 1, qh, ());
-                    state.output = Some(output);
-                }*/
-                "zwp_input_method_manager_v2" => {
-                    let manager = registry
-                        .bind::<zwp_input_method_manager_v2::ZwpInputMethodManagerV2, _, _>(
-                            name,
-                            1, // TODO: should this be 2?
-                            qh,
-                            (),
-                        );
-                    state.im_manager = Some(manager);
-                }
-                "zwp_virtual_keyboard_manager_v1" => {
-                    let manager = registry
-                        .bind::<zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1, _, _>(
-                        name,
-                        1,
-                        qh,
-                        (),
-                    );
-                    state.keyboard_manager = Some(manager);
-                }
-                "zwlr_virtual_pointer_manager_v1" => {
-                    let manager = registry
-                        .bind::<zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1, _, _>(
-                        name,
-                        1,
-                        qh,
-                        (),
-                    );
-                    state.pointer_manager = Some(manager);
-                }
-                s => {
-                    trace!("i: {}", s);
-                }
-            }
+            trace!(
+                "Global announced: {} (name: {}, version: {})",
+                interface,
+                name,
+                version
+            );
+            state.globals.insert(interface, (name, version));
         }
     }
 }
@@ -448,24 +524,74 @@ impl Dispatch<zwp_input_method_v2::ZwpInputMethodV2, ()> for WaylandState {
         _: &Connection,
         _qh: &QueueHandle<Self>,
     ) {
+        warn!("Got a input method event {:?}", event);
         match event {
             zwp_input_method_v2::Event::Done => state.im_serial += Wrapping(1u32),
             _ => (), // TODO
         }
-        warn!("Got a input method event {:?}", event);
     }
 }
 
 impl Dispatch<wl_seat::WlSeat, ()> for WaylandState {
     fn event(
-        _state: &mut Self,
-        _seat: &wl_seat::WlSeat,
+        state: &mut Self,
+        seat: &wl_seat::WlSeat,
         event: wl_seat::Event,
+        (): &(),
+        _con: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        warn!("Received a seat event {:?}", event);
+        if let wl_seat::Event::Capabilities { capabilities } = event {
+            let capabilities = match capabilities {
+                wayland_client::WEnum::Value(capabilities) => capabilities,
+                wayland_client::WEnum::Unknown(v) => {
+                    warn!("Unknown value for the capabilities of the wl_seat: {v}");
+                    return;
+                }
+            };
+
+            // Create a WlKeyboard if the seat has the capability
+            if state.seat_keyboard.is_none() && capabilities.contains(Capability::Keyboard) {
+                let seat_keyboard = seat.get_keyboard(qh, ());
+                state.seat_keyboard = Some(seat_keyboard);
+            }
+
+            // Create a WlPointer if the seat has the capability
+            if state.seat_pointer.is_none() && capabilities.contains(Capability::Pointer) {
+                let seat_pointer = seat.get_pointer(qh, ());
+                state.seat_pointer = Some(seat_pointer);
+            }
+        } else {
+            // TODO: Handle the case of removed capabilities
+            warn!("Event was not handled");
+        }
+    }
+}
+
+impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandState {
+    fn event(
+        _state: &mut Self,
+        _seat: &wl_keyboard::WlKeyboard,
+        event: wl_keyboard::Event,
         (): &(),
         _: &Connection,
         _qh: &QueueHandle<Self>,
     ) {
-        warn!("Got a seat event {:?}", event);
+        warn!("Got a wl_keyboard event {:?}", event);
+    }
+}
+
+impl Dispatch<wl_pointer::WlPointer, ()> for WaylandState {
+    fn event(
+        _state: &mut Self,
+        _seat: &wl_pointer::WlPointer,
+        event: wl_pointer::Event,
+        (): &(),
+        _: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        warn!("Got a wl_pointer event {:?}", event);
     }
 }
 
@@ -560,10 +686,9 @@ impl Keyboard for Con {
         im.commit_string(text.to_string());
         im.commit(self.state.im_serial.0);
 
-        // TODO: Change to flush()
         self.event_queue
-            .roundtrip(&mut self.state)
-            .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))?;
+            .flush()
+            .map_err(|_| InputError::Simulate("Flushing Wayland queue failed"))?;
 
         Ok(Some(()))
     }
@@ -641,11 +766,9 @@ impl Mouse for Con {
             vp.button(time, button, wl_pointer::ButtonState::Released);
             vp.frame(); // TODO: Check if this is needed
         }
-        // TODO: Change to flush()
         self.event_queue
-            .roundtrip(&mut self.state)
-            .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))
-            .map(|_| ())
+            .flush()
+            .map_err(|_| InputError::Simulate("Flushing Wayland queue failed"))
     }
 
     fn move_mouse(&mut self, x: i32, y: i32, coordinate: Coordinate) -> InputResult<()> {

--- a/tests/integration_browser.rs
+++ b/tests/integration_browser.rs
@@ -1,12 +1,7 @@
 use enigo::{
-    Axis::{Horizontal, Vertical},
-    // Button,
     Coordinate::{Abs, Rel},
     Direction::{Click, Press, Release},
-    Key,
-    Keyboard,
-    Mouse as _,
-    Settings,
+    Key, Keyboard, Mouse as _, Settings,
 };
 
 mod common;


### PR DESCRIPTION
Bind to the globals in the correct order and make sure Wayland objects are created before they are used. Sending messages to objects before they were created caused `labwc` to crash.

Instead of doing a roundtrip each time when we send a message to the server, the queue gets flushed to improve the performance,