### PR TITLE
Bump MSRV and Rust edition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.82.0"
+          - "1.85.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/failing_tests.yml
+++ b/.github/workflows/failing_tests.yml
@@ -22,7 +22,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.82.0"
+          - "1.85.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.82.0"
+          - "1.85.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.82.0"
+          - "1.85.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Unreleased
 ## Changed
-- Rust: MSRV is 1.82
+- Rust: MSRV is 1.85
 
 ## Added
 - macOS: Add to support Mouse special key(Back, Forward)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Unreleased
 ## Changed
 - Rust: MSRV is 1.85
+- Rust: Use edition 2024
 
 ## Added
 - macOS: Add to support Mouse special key(Back, Forward)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "pentamassiv <pentamassiv@posteo.de>",
     "Dustin Bensing <dustin.bensing@googlemail.com>",
 ]
-edition = "2021"
+edition = "2024"
 rust-version = "1.85"
 description = "Cross-platform (Linux, Windows, macOS & BSD) library to simulate keyboard and mouse events"
 documentation = "https://docs.rs/enigo/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Dustin Bensing <dustin.bensing@googlemail.com>",
 ]
 edition = "2021"
-rust-version = "1.82"
+rust-version = "1.85"
 description = "Cross-platform (Linux, Windows, macOS & BSD) library to simulate keyboard and mouse events"
 documentation = "https://docs.rs/enigo/"
 homepage = "https://github.com/enigo-rs/enigo"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Docs](https://docs.rs/enigo/badge.svg)](https://docs.rs/enigo)
 [![Dependency status](https://deps.rs/repo/github/enigo-rs/enigo/status.svg)](https://deps.rs/repo/github/enigo-rs/enigo)
 
-![Rust version](https://img.shields.io/badge/rust--version-1.82+-brightgreen.svg)
+![Rust version](https://img.shields.io/badge/rust--version-1.85+-brightgreen.svg)
 [![Crates.io](https://img.shields.io/crates/v/enigo.svg)](https://crates.io/crates/enigo)
 
 # enigo

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -1,6 +1,6 @@
 use enigo::{
-    agent::{Agent, Token},
     Button, Enigo, Key, Settings,
+    agent::{Agent, Token},
 };
 use std::{thread, time::Duration};
 

--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -739,7 +739,7 @@ impl TryFrom<Key> for windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY {
     #[allow(clippy::too_many_lines)]
     fn try_from(key: Key) -> Result<Self, Self::Error> {
         use windows::Win32::UI::Input::KeyboardAndMouse::{
-            VK__none_, VIRTUAL_KEY, VK_0, VK_1, VK_2, VK_3, VK_4, VK_5, VK_6, VK_7, VK_8, VK_9,
+            VIRTUAL_KEY, VK__none_, VK_0, VK_1, VK_2, VK_3, VK_4, VK_5, VK_6, VK_7, VK_8, VK_9,
             VK_A, VK_ABNT_C1, VK_ABNT_C2, VK_ACCEPT, VK_ADD, VK_APPS, VK_ATTN, VK_B, VK_BACK,
             VK_BROWSER_BACK, VK_BROWSER_FAVORITES, VK_BROWSER_FORWARD, VK_BROWSER_HOME,
             VK_BROWSER_REFRESH, VK_BROWSER_SEARCH, VK_BROWSER_STOP, VK_C, VK_CANCEL, VK_CAPITAL,
@@ -748,9 +748,9 @@ impl TryFrom<Key> for windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY {
             VK_DBE_ENTERDLGCONVERSIONMODE, VK_DBE_ENTERIMECONFIGMODE, VK_DBE_ENTERWORDREGISTERMODE,
             VK_DBE_FLUSHSTRING, VK_DBE_HIRAGANA, VK_DBE_KATAKANA, VK_DBE_NOCODEINPUT,
             VK_DBE_NOROMAN, VK_DBE_ROMAN, VK_DBE_SBCSCHAR, VK_DECIMAL, VK_DELETE, VK_DIVIDE,
-            VK_DOWN, VK_E, VK_END, VK_EREOF, VK_ESCAPE, VK_EXECUTE, VK_EXSEL, VK_F, VK_F1, VK_F10,
-            VK_F11, VK_F12, VK_F13, VK_F14, VK_F15, VK_F16, VK_F17, VK_F18, VK_F19, VK_F2, VK_F20,
-            VK_F21, VK_F22, VK_F23, VK_F24, VK_F3, VK_F4, VK_F5, VK_F6, VK_F7, VK_F8, VK_F9,
+            VK_DOWN, VK_E, VK_END, VK_EREOF, VK_ESCAPE, VK_EXECUTE, VK_EXSEL, VK_F, VK_F1, VK_F2,
+            VK_F3, VK_F4, VK_F5, VK_F6, VK_F7, VK_F8, VK_F9, VK_F10, VK_F11, VK_F12, VK_F13,
+            VK_F14, VK_F15, VK_F16, VK_F17, VK_F18, VK_F19, VK_F20, VK_F21, VK_F22, VK_F23, VK_F24,
             VK_FINAL, VK_G, VK_GAMEPAD_A, VK_GAMEPAD_B, VK_GAMEPAD_DPAD_DOWN, VK_GAMEPAD_DPAD_LEFT,
             VK_GAMEPAD_DPAD_RIGHT, VK_GAMEPAD_DPAD_UP, VK_GAMEPAD_LEFT_SHOULDER,
             VK_GAMEPAD_LEFT_THUMBSTICK_BUTTON, VK_GAMEPAD_LEFT_THUMBSTICK_DOWN,
@@ -769,17 +769,18 @@ impl TryFrom<Key> for windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY {
             VK_NAVIGATION_DOWN, VK_NAVIGATION_LEFT, VK_NAVIGATION_MENU, VK_NAVIGATION_RIGHT,
             VK_NAVIGATION_UP, VK_NAVIGATION_VIEW, VK_NEXT, VK_NONAME, VK_NONCONVERT, VK_NUMLOCK,
             VK_NUMPAD0, VK_NUMPAD1, VK_NUMPAD2, VK_NUMPAD3, VK_NUMPAD4, VK_NUMPAD5, VK_NUMPAD6,
-            VK_NUMPAD7, VK_NUMPAD8, VK_NUMPAD9, VK_O, VK_OEM_1, VK_OEM_102, VK_OEM_2, VK_OEM_3,
-            VK_OEM_4, VK_OEM_5, VK_OEM_6, VK_OEM_7, VK_OEM_8, VK_OEM_ATTN, VK_OEM_AUTO, VK_OEM_AX,
-            VK_OEM_BACKTAB, VK_OEM_CLEAR, VK_OEM_COMMA, VK_OEM_COPY, VK_OEM_CUSEL, VK_OEM_ENLW,
-            VK_OEM_FINISH, VK_OEM_FJ_JISHO, VK_OEM_FJ_LOYA, VK_OEM_FJ_MASSHOU, VK_OEM_FJ_ROYA,
-            VK_OEM_FJ_TOUROKU, VK_OEM_JUMP, VK_OEM_MINUS, VK_OEM_NEC_EQUAL, VK_OEM_PA1, VK_OEM_PA2,
-            VK_OEM_PA3, VK_OEM_PERIOD, VK_OEM_PLUS, VK_OEM_RESET, VK_OEM_WSCTRL, VK_P, VK_PA1,
-            VK_PACKET, VK_PAUSE, VK_PLAY, VK_PRINT, VK_PRIOR, VK_PROCESSKEY, VK_Q, VK_R,
-            VK_RBUTTON, VK_RCONTROL, VK_RETURN, VK_RIGHT, VK_RMENU, VK_RSHIFT, VK_RWIN, VK_S,
-            VK_SCROLL, VK_SELECT, VK_SEPARATOR, VK_SHIFT, VK_SLEEP, VK_SNAPSHOT, VK_SPACE,
-            VK_SUBTRACT, VK_T, VK_TAB, VK_U, VK_UP, VK_V, VK_VOLUME_DOWN, VK_VOLUME_MUTE,
-            VK_VOLUME_UP, VK_W, VK_X, VK_XBUTTON1, VK_XBUTTON2, VK_Y, VK_Z, VK_ZOOM,
+            VK_NUMPAD7, VK_NUMPAD8, VK_NUMPAD9, VK_O, VK_OEM_1, VK_OEM_2, VK_OEM_3, VK_OEM_4,
+            VK_OEM_5, VK_OEM_6, VK_OEM_7, VK_OEM_8, VK_OEM_102, VK_OEM_ATTN, VK_OEM_AUTO,
+            VK_OEM_AX, VK_OEM_BACKTAB, VK_OEM_CLEAR, VK_OEM_COMMA, VK_OEM_COPY, VK_OEM_CUSEL,
+            VK_OEM_ENLW, VK_OEM_FINISH, VK_OEM_FJ_JISHO, VK_OEM_FJ_LOYA, VK_OEM_FJ_MASSHOU,
+            VK_OEM_FJ_ROYA, VK_OEM_FJ_TOUROKU, VK_OEM_JUMP, VK_OEM_MINUS, VK_OEM_NEC_EQUAL,
+            VK_OEM_PA1, VK_OEM_PA2, VK_OEM_PA3, VK_OEM_PERIOD, VK_OEM_PLUS, VK_OEM_RESET,
+            VK_OEM_WSCTRL, VK_P, VK_PA1, VK_PACKET, VK_PAUSE, VK_PLAY, VK_PRINT, VK_PRIOR,
+            VK_PROCESSKEY, VK_Q, VK_R, VK_RBUTTON, VK_RCONTROL, VK_RETURN, VK_RIGHT, VK_RMENU,
+            VK_RSHIFT, VK_RWIN, VK_S, VK_SCROLL, VK_SELECT, VK_SEPARATOR, VK_SHIFT, VK_SLEEP,
+            VK_SNAPSHOT, VK_SPACE, VK_SUBTRACT, VK_T, VK_TAB, VK_U, VK_UP, VK_V, VK_VOLUME_DOWN,
+            VK_VOLUME_MUTE, VK_VOLUME_UP, VK_W, VK_X, VK_XBUTTON1, VK_XBUTTON2, VK_Y, VK_Z,
+            VK_ZOOM,
         };
 
         trace!("Key::try_from(key: {key:?})");
@@ -1036,7 +1037,7 @@ impl TryFrom<Key> for windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY {
                     '\n' => break 'unicode_handling VK_RETURN,
 
                     '\r' => { // TODO: What is the correct key to type here?
-                         // break 'unicode_handling VK_,
+                        // break 'unicode_handling VK_,
                     }
                     '\t' => break 'unicode_handling VK_TAB,
                     '\0' => {
@@ -1057,7 +1058,7 @@ impl TryFrom<Key> for windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY {
                 // virtual-key code and the high-order byte contains the shift state, which can
                 // be a combination of the following flag bits. If the function finds no key
                 // that translates to the passed character code, both the low-order and
-                // high-order bytes contain –1
+                // high-order bytes contain -1
                 let vk = unsafe {
                     windows::Win32::UI::Input::KeyboardAndMouse::VkKeyScanExW(
                         utf16_surrogates[0],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,9 +74,9 @@ mod platform;
 pub use platform::Enigo;
 
 #[cfg(target_os = "windows")]
-pub use platform::set_dpi_awareness;
-#[cfg(target_os = "windows")]
 pub use platform::EXT;
+#[cfg(target_os = "windows")]
+pub use platform::set_dpi_awareness;
 
 mod keycodes;
 /// Contains the available keycodes

--- a/src/linux/keymap.rs
+++ b/src/linux/keymap.rs
@@ -39,14 +39,14 @@ pub struct KeyMap<Keycode> {
 
 // TODO: Check if the bounds can be simplified
 impl<
-        Keycode: std::ops::Sub
-            + PartialEq
-            + Copy
-            + Clone
-            + Display
-            + TryInto<usize>
-            + std::convert::TryFrom<usize>,
-    > KeyMap<Keycode>
+    Keycode: std::ops::Sub
+        + PartialEq
+        + Copy
+        + Clone
+        + Display
+        + TryInto<usize>
+        + std::convert::TryFrom<usize>,
+> KeyMap<Keycode>
 where
     <Keycode as TryInto<usize>>::Error: std::fmt::Debug,
     <Keycode as TryFrom<usize>>::Error: std::fmt::Debug,
@@ -173,8 +173,7 @@ where
             Some(unused_keycode) => {
                 trace!(
                     "trying to map keycode {} to keysym {:?}",
-                    unused_keycode,
-                    keysym
+                    unused_keycode, keysym
                 );
                 if c.bind_key(unused_keycode, keysym).is_err() {
                     return Err(InputError::Mapping(format!("{keysym:?}")));

--- a/src/linux/libei.rs
+++ b/src/linux/libei.rs
@@ -1,9 +1,9 @@
 use ashpd::desktop::remote_desktop::RemoteDesktop;
 use log::{debug, error, trace, warn};
 use reis::{
+    PendingRequestResult,
     ei::{self, Connection},
     handshake::HandshakeResp,
-    PendingRequestResult,
 };
 use std::{collections::HashMap, os::unix::net::UnixStream, time::Instant};
 use xkbcommon::xkb;
@@ -182,7 +182,7 @@ impl Con {
         con.update(libei_name)
             .map_err(|_| NewConError::EstablishCon("unable to update the libei connection"))?;
 
-        for (device, device_data) in con.devices.iter_mut().filter(|(_, ref device_data)| {
+        for (device, device_data) in con.devices.iter_mut().filter(|(_, device_data)| {
             device_data.device_type == Some(reis::ei::device::DeviceType::Virtual)
                 && device_data.state == DeviceState::Resumed
             // TODO: Should all devices start emulating?
@@ -281,7 +281,9 @@ impl Con {
                             invalid_id,
                         } => {
                             // TODO: Try to recover?
-                            error!("the serial {last_serial} contained an invalid object with the id {invalid_id}");
+                            error!(
+                                "the serial {last_serial} contained an invalid object with the id {invalid_id}"
+                            );
                         }
                         ei::connection::Event::Ping { ping } => {
                             debug!("ping");
@@ -434,11 +436,11 @@ impl Con {
                                 latched,
                                 group,
                             } => { // TODO: Handle updated modifiers
-                                 // Notification that the EIS
-                                 // implementation has changed modifier states
-                                 // on this device. Future ei_keyboard.key
-                                 // requests must take the new modifier state
-                                 // into account.
+                                // Notification that the EIS
+                                // implementation has changed modifier states
+                                // on this device. Future ei_keyboard.key
+                                // requests must take the new modifier state
+                                // into account.
                             }
                             _ => {}
                         }
@@ -484,7 +486,7 @@ impl Keyboard for Con {
         if let Some((device, device_data)) = self
             .devices
             .iter_mut()
-            .find(|(_, ref device_data)| device_data.interface::<ei::Keyboard>().is_some())
+            .find(|(_, device_data)| device_data.interface::<ei::Keyboard>().is_some())
         {
             if let Some((keyboard, keymap)) = self.keyboards.iter().next() {
                 let keycode = key_to_keycode(keymap, key)?;
@@ -514,7 +516,7 @@ impl Keyboard for Con {
         if let Some((device, device_data)) = self
             .devices
             .iter_mut()
-            .find(|(_, ref device_data)| device_data.interface::<ei::Keyboard>().is_some())
+            .find(|(_, device_data)| device_data.interface::<ei::Keyboard>().is_some())
         {
             let keyboard = device_data.interface::<ei::Keyboard>().unwrap();
 
@@ -542,7 +544,7 @@ impl Mouse for Con {
         if let Some((device, device_data)) = self
             .devices
             .iter_mut()
-            .find(|(_, ref device_data)| device_data.interface::<ei::Button>().is_some())
+            .find(|(_, device_data)| device_data.interface::<ei::Button>().is_some())
         {
             // Do nothing if one of the mouse scroll buttons was released
             // Releasing one of the scroll mouse buttons has no effect
@@ -691,13 +693,17 @@ impl Mouse for Con {
 
     fn main_display(&self) -> InputResult<(i32, i32)> {
         // TODO Implement this
-        error!("You tried to get the dimensions of the main display. I don't know how this is possible under Wayland. Let me know if there is a new protocol");
+        error!(
+            "You tried to get the dimensions of the main display. I don't know how this is possible under Wayland. Let me know if there is a new protocol"
+        );
         Err(InputError::Simulate("Not implemented yet"))
     }
 
     fn location(&self) -> InputResult<(i32, i32)> {
         // TODO Implement this
-        error!("You tried to get the mouse location. I don't know how this is possible under Wayland. Let me know if there is a new protocol");
+        error!(
+            "You tried to get the mouse location. I don't know how this is possible under Wayland. Let me know if there is a new protocol"
+        );
         Err(InputError::Simulate("Not implemented yet"))
     }
 }
@@ -716,7 +722,7 @@ impl Drop for Con {
         self.connection.disconnect(); // Let the server know we voluntarily disconnected
 
         let _ = self.context.flush(); // Ignore the errors if the connection was
-                                      // dropped
+        // dropped
     }
 }
 

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     feature = "libei"
 )))]
 compile_error!(
-   "either feature `wayland`, `x11rb`, `xdo` or `libei` must be enabled for this crate when using linux"
+    "either feature `wayland`, `x11rb`, `xdo` or `libei` must be enabled for this crate when using linux"
 );
 
 #[cfg(feature = "libei")]

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -10,13 +10,13 @@ use std::{
 
 use log::{debug, error, trace, warn};
 use wayland_client::{
+    Connection, Dispatch, EventQueue, QueueHandle,
     protocol::{
         wl_keyboard::{self, WlKeyboard},
         wl_pointer::{self, WlPointer},
         wl_registry,
         wl_seat::{self, Capability},
     },
-    Connection, Dispatch, EventQueue, QueueHandle,
 };
 use wayland_protocols_misc::{
     zwp_input_method_v2::client::{zwp_input_method_manager_v2, zwp_input_method_v2},
@@ -28,8 +28,8 @@ use wayland_protocols_wlr::virtual_pointer::v1::client::{
 
 use super::keymap::{Bind, KeyMap};
 use crate::{
-    keycodes::Modifier, keycodes::ModifierBitflag, Axis, Button, Coordinate, Direction, InputError,
-    InputResult, Key, Keyboard, Mouse, NewConError,
+    Axis, Button, Coordinate, Direction, InputError, InputResult, Key, Keyboard, Mouse,
+    NewConError, keycodes::Modifier, keycodes::ModifierBitflag,
 };
 
 pub type Keycode = u32;
@@ -468,9 +468,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
         {
             trace!(
                 "Global announced: {} (name: {}, version: {})",
-                interface,
-                name,
-                version
+                interface, name, version
             );
             state.globals.insert(interface, (name, version));
         }
@@ -836,13 +834,17 @@ impl Mouse for Con {
 
     fn main_display(&self) -> InputResult<(i32, i32)> {
         // TODO Implement this
-        error!("You tried to get the dimensions of the main display. I don't know how this is possible under Wayland. Let me know if there is a new protocol");
+        error!(
+            "You tried to get the dimensions of the main display. I don't know how this is possible under Wayland. Let me know if there is a new protocol"
+        );
         Err(InputError::Simulate("Not implemented yet"))
     }
 
     fn location(&self) -> InputResult<(i32, i32)> {
         // TODO Implement this
-        error!("You tried to get the mouse location. I don't know how this is possible under Wayland. Let me know if there is a new protocol");
+        error!(
+            "You tried to get the mouse location. I don't know how this is possible under Wayland. Let me know if there is a new protocol"
+        );
         Err(InputError::Simulate("Not implemented yet"))
     }
 }

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -16,8 +16,8 @@ use x11rb::{
 
 use super::keymap::{Bind, KeyMap, Keysym};
 use crate::{
-    keycodes::Modifier, Axis, Button, Coordinate, Direction, InputError, InputResult, Key,
-    Keyboard, Mouse, NewConError,
+    Axis, Button, Coordinate, Direction, InputError, InputResult, Key, Keyboard, Mouse,
+    NewConError, keycodes::Modifier,
 };
 
 type CompositorConnection = RustConnection<DefaultStream>;

--- a/src/linux/xdo.rs
+++ b/src/linux/xdo.rs
@@ -1,5 +1,5 @@
 use std::{
-    ffi::{c_char, c_int, c_ulong, c_void, CString},
+    ffi::{CString, c_char, c_int, c_ulong, c_void},
     ptr,
 };
 
@@ -19,7 +19,7 @@ type Window = c_ulong;
 type Xdo = *const c_void;
 
 #[link(name = "xdo")]
-extern "C" {
+unsafe extern "C" {
     fn xdo_free(xdo: Xdo);
     fn xdo_new(display: *const c_char) -> Xdo;
 

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -6,7 +6,7 @@ use std::{
 
 use core_foundation::{
     array::CFIndex,
-    base::{OSStatus, TCFType, UInt16, UInt32, UInt8},
+    base::{OSStatus, TCFType, UInt8, UInt16, UInt32},
     data::{CFDataGetBytePtr, CFDataRef},
     dictionary::{CFDictionary, CFDictionaryRef},
     string::{CFString, CFStringRef, UniChar},
@@ -59,7 +59,7 @@ const kUCKeyTranslateNoDeadKeysBit: CFIndex = 0; // Previously was always u32. C
 
 #[allow(improper_ctypes)]
 #[link(name = "Carbon", kind = "framework")]
-extern "C" {
+unsafe extern "C" {
     fn TISCopyCurrentKeyboardInputSource() -> TISInputSourceRef;
     fn TISCopyCurrentKeyboardLayoutInputSource() -> TISInputSourceRef;
     fn TISCopyCurrentASCIICapableKeyboardLayoutInputSource() -> TISInputSourceRef;
@@ -165,7 +165,9 @@ impl Mouse for Enigo {
                 | Button::ScrollDown
                 | Button::ScrollLeft
                 | Button::ScrollRight => {
-                    info!("On macOS the mouse_up function has no effect when called with one of the Scroll buttons");
+                    info!(
+                        "On macOS the mouse_up function has no effect when called with one of the Scroll buttons"
+                    );
                     return Ok(());
                 }
             };
@@ -210,8 +212,8 @@ impl Mouse for Enigo {
             (CGEventType::RightMouseDragged, CGMouseButton::Right)
         } else {
             (CGEventType::MouseMoved, CGMouseButton::Left) // The mouse button
-                                                           // here is ignored so
-                                                           // it can be anything
+            // here is ignored so
+            // it can be anything
         };
 
         let dest = CGPoint::new(absolute.0 as f64, absolute.1 as f64);
@@ -549,7 +551,7 @@ impl Enigo {
 
         let mut event_flags = CGEventFlags::CGEventFlagNonCoalesced;
         event_flags.set(CGEventFlags::from_bits_retain(0x2000_0000), true); // I don't know if this is needed or what this flag does. Correct events have it
-                                                                            // set so we also do it (until we know it is wrong)
+        // set so we also do it (until we know it is wrong)
 
         let double_click_delay = Duration::from_secs(1);
         let double_click_delay_setting = unsafe { NSEvent::doubleClickInterval() };
@@ -898,7 +900,9 @@ impl Enigo {
 
         let flag_fn = match direction {
             Direction::Click => {
-                unreachable!("The function should never get called with Direction::Click. If it was, it's an implementation error");
+                unreachable!(
+                    "The function should never get called with Direction::Click. If it was, it's an implementation error"
+                );
             }
             Direction::Press => press_fn,
             Direction::Release => release_fn,
@@ -1065,7 +1069,9 @@ fn keycode_to_string(keycode: u16, modifier: u32) -> Result<String, String> {
     let mut layout_data =
         unsafe { TISGetInputSourceProperty(current_keyboard, kTISPropertyUnicodeKeyLayoutData) };
     if layout_data.is_null() {
-        debug!("TISGetInputSourceProperty(current_keyboard, kTISPropertyUnicodeKeyLayoutData) returned NULL");
+        debug!(
+            "TISGetInputSourceProperty(current_keyboard, kTISPropertyUnicodeKeyLayoutData) returned NULL"
+        );
         // TISGetInputSourceProperty returns null with some keyboard layout.
         // Using TISCopyCurrentKeyboardLayoutInputSource to fix NULL return.
         // See also: https://github.com/microsoft/node-native-keymap/blob/089d802efd387df4dce1f0e31898c66e28b3f67f/src/keyboard_mac.mm#L90
@@ -1074,7 +1080,9 @@ fn keycode_to_string(keycode: u16, modifier: u32) -> Result<String, String> {
             TISGetInputSourceProperty(current_keyboard, kTISPropertyUnicodeKeyLayoutData)
         };
         if layout_data.is_null() {
-            debug!("TISGetInputSourceProperty(current_keyboard, kTISPropertyUnicodeKeyLayoutData) returned NULL again");
+            debug!(
+                "TISGetInputSourceProperty(current_keyboard, kTISPropertyUnicodeKeyLayoutData) returned NULL again"
+            );
             current_keyboard = unsafe { TISCopyCurrentASCIICapableKeyboardLayoutInputSource() };
             layout_data = unsafe {
                 TISGetInputSourceProperty(current_keyboard, kTISPropertyUnicodeKeyLayoutData)
@@ -1117,7 +1125,7 @@ fn keycode_to_string(keycode: u16, modifier: u32) -> Result<String, String> {
 }
 
 #[link(name = "ApplicationServices", kind = "framework")]
-extern "C" {
+unsafe extern "C" {
     pub fn AXIsProcessTrustedWithOptions(options: CFDictionaryRef) -> bool;
     static kAXTrustedCheckOptionPrompt: CFStringRef;
 }

--- a/src/tests/mouse.rs
+++ b/src/tests/mouse.rs
@@ -29,17 +29,17 @@ fn test_mouse_move(
     for test_case in test_cases {
         for mouse_action in test_case {
             enigo
-                .move_mouse(mouse_action.0 .0, mouse_action.0 .1, coordinate)
+                .move_mouse(mouse_action.0.0, mouse_action.0.1, coordinate)
                 .unwrap();
             thread::sleep(delay);
             let (x_res, y_res) = enigo.location().unwrap();
             assert_eq!(
-                (mouse_action.1 .0, mouse_action.1 .1),
+                (mouse_action.1.0, mouse_action.1.1),
                 (x_res, y_res),
                 "{} {}, {}",
                 error_text,
-                mouse_action.0 .0,
-                mouse_action.0 .1
+                mouse_action.0.0,
+                mouse_action.0.1
             );
             thread::sleep(delay);
         }

--- a/src/win/mod.rs
+++ b/src/win/mod.rs
@@ -1,2 +1,2 @@
 mod win_impl;
-pub use win_impl::{set_dpi_awareness, Enigo, EXT};
+pub use win_impl::{EXT, Enigo, set_dpi_awareness};

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -4,13 +4,13 @@ use log::{debug, error, info, warn};
 use windows::Win32::Foundation::POINT;
 use windows::Win32::UI::{
     Input::KeyboardAndMouse::{
-        GetKeyboardLayout, MapVirtualKeyExW, SendInput, HKL, INPUT, INPUT_0, INPUT_KEYBOARD,
-        INPUT_MOUSE, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP,
-        KEYEVENTF_SCANCODE, KEYEVENTF_UNICODE, MAPVK_VK_TO_VSC_EX, MAPVK_VSC_TO_VK_EX,
-        MAP_VIRTUAL_KEY_TYPE, MOUSEEVENTF_ABSOLUTE, MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN,
-        MOUSEEVENTF_LEFTUP, MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP, MOUSEEVENTF_MOVE,
-        MOUSEEVENTF_RIGHTDOWN, MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_WHEEL, MOUSEEVENTF_XDOWN,
-        MOUSEEVENTF_XUP, MOUSEINPUT, MOUSE_EVENT_FLAGS, VIRTUAL_KEY,
+        GetKeyboardLayout, HKL, INPUT, INPUT_0, INPUT_KEYBOARD, INPUT_MOUSE, KEYBD_EVENT_FLAGS,
+        KEYBDINPUT, KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP, KEYEVENTF_SCANCODE, KEYEVENTF_UNICODE,
+        MAP_VIRTUAL_KEY_TYPE, MAPVK_VK_TO_VSC_EX, MAPVK_VSC_TO_VK_EX, MOUSE_EVENT_FLAGS,
+        MOUSEEVENTF_ABSOLUTE, MOUSEEVENTF_HWHEEL, MOUSEEVENTF_LEFTDOWN, MOUSEEVENTF_LEFTUP,
+        MOUSEEVENTF_MIDDLEDOWN, MOUSEEVENTF_MIDDLEUP, MOUSEEVENTF_MOVE, MOUSEEVENTF_RIGHTDOWN,
+        MOUSEEVENTF_RIGHTUP, MOUSEEVENTF_WHEEL, MOUSEEVENTF_XDOWN, MOUSEEVENTF_XUP, MOUSEINPUT,
+        MapVirtualKeyExW, SendInput, VIRTUAL_KEY,
     },
     WindowsAndMessaging::{GetForegroundWindow, GetWindowThreadProcessId},
 };
@@ -142,7 +142,9 @@ impl Mouse for Enigo {
                 | Button::ScrollDown
                 | Button::ScrollLeft
                 | Button::ScrollRight => {
-                    info!("On Windows the mouse_up function has no effect when called with one of the Scroll buttons");
+                    info!(
+                        "On Windows the mouse_up function has no effect when called with one of the Scroll buttons"
+                    );
                     return Ok(());
                 }
             };
@@ -194,13 +196,17 @@ impl Mouse for Enigo {
             // (fastest) and represents how much the pointer moves based on the distance the
             // mouse moves. The default value is 10, which results in no additional
             // modification to the mouse motion.
-            debug!("\x1b[93mRelative mouse move is subject to mouse speed and acceleration level\x1b[0m");
+            debug!(
+                "\x1b[93mRelative mouse move is subject to mouse speed and acceleration level\x1b[0m"
+            );
             (MOUSEEVENTF_MOVE, x, y)
         } else {
             // Instead of moving the mouse by a relative amount, we calculate the resulting
             // location and move it to the absolute location so it is not subject to mouse
             // speed and acceleration levels
-            debug!("\x1b[93mRelative mouse move is NOT subject to mouse speed and acceleration level\x1b[0m");
+            debug!(
+                "\x1b[93mRelative mouse move is NOT subject to mouse speed and acceleration level\x1b[0m"
+            );
             let (current_x, current_y) = self.location()?;
             return self.move_mouse(current_x + x, current_y + y, Coordinate::Abs);
         };
@@ -406,7 +412,10 @@ impl Enigo {
         match unsafe { MapVirtualKeyExW(input.into(), map_type, layout) }.try_into() {
             Ok(output) => {
                 if output == 0 {
-                    warn!("The result for the input {:?} is zero. This usually means there was no mapping", input);
+                    warn!(
+                        "The result for the input {:?} is zero. This usually means there was no mapping",
+                        input
+                    );
                 }
                 Ok(output)
             }
@@ -550,8 +559,7 @@ impl Enigo {
 /// already been set (via a previous API call or within the application
 /// manifest)
 pub fn set_dpi_awareness() -> Result<(), ()> {
-    use windows::Win32::UI::HiDpi::SetProcessDpiAwareness;
-    use windows::Win32::UI::HiDpi::PROCESS_PER_MONITOR_DPI_AWARE;
+    use windows::Win32::UI::HiDpi::{PROCESS_PER_MONITOR_DPI_AWARE, SetProcessDpiAwareness};
 
     unsafe { SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE) }.map_err(|_| ())
 }
@@ -625,9 +633,9 @@ mod test {
             VK_DBE_ENTERDLGCONVERSIONMODE, VK_DBE_ENTERIMECONFIGMODE, VK_DBE_ENTERWORDREGISTERMODE,
             VK_DBE_FLUSHSTRING, VK_DBE_HIRAGANA, VK_DBE_KATAKANA, VK_DBE_NOCODEINPUT,
             VK_DBE_NOROMAN, VK_DBE_ROMAN, VK_DBE_SBCSCHAR, VK_DECIMAL, VK_E, VK_EREOF, VK_ESCAPE,
-            VK_EXECUTE, VK_EXSEL, VK_F, VK_F1, VK_F10, VK_F11, VK_F12, VK_F13, VK_F14, VK_F15,
-            VK_F16, VK_F17, VK_F18, VK_F19, VK_F2, VK_F20, VK_F21, VK_F22, VK_F23, VK_F24, VK_F3,
-            VK_F4, VK_F5, VK_F6, VK_F7, VK_F8, VK_F9, VK_FINAL, VK_G, VK_GAMEPAD_A, VK_GAMEPAD_B,
+            VK_EXECUTE, VK_EXSEL, VK_F, VK_F1, VK_F2, VK_F3, VK_F4, VK_F5, VK_F6, VK_F7, VK_F8,
+            VK_F9, VK_F10, VK_F11, VK_F12, VK_F13, VK_F14, VK_F15, VK_F16, VK_F17, VK_F18, VK_F19,
+            VK_F20, VK_F21, VK_F22, VK_F23, VK_F24, VK_FINAL, VK_G, VK_GAMEPAD_A, VK_GAMEPAD_B,
             VK_GAMEPAD_DPAD_DOWN, VK_GAMEPAD_DPAD_LEFT, VK_GAMEPAD_DPAD_RIGHT, VK_GAMEPAD_DPAD_UP,
             VK_GAMEPAD_LEFT_SHOULDER, VK_GAMEPAD_LEFT_THUMBSTICK_BUTTON,
             VK_GAMEPAD_LEFT_THUMBSTICK_DOWN, VK_GAMEPAD_LEFT_THUMBSTICK_LEFT,
@@ -645,17 +653,17 @@ mod test {
             VK_NAVIGATION_CANCEL, VK_NAVIGATION_DOWN, VK_NAVIGATION_LEFT, VK_NAVIGATION_MENU,
             VK_NAVIGATION_RIGHT, VK_NAVIGATION_UP, VK_NAVIGATION_VIEW, VK_NONAME, VK_NONCONVERT,
             VK_NUMPAD0, VK_NUMPAD1, VK_NUMPAD2, VK_NUMPAD3, VK_NUMPAD4, VK_NUMPAD5, VK_NUMPAD6,
-            VK_NUMPAD7, VK_NUMPAD8, VK_NUMPAD9, VK_O, VK_OEM_1, VK_OEM_102, VK_OEM_2, VK_OEM_3,
-            VK_OEM_4, VK_OEM_5, VK_OEM_6, VK_OEM_7, VK_OEM_8, VK_OEM_ATTN, VK_OEM_AUTO, VK_OEM_AX,
-            VK_OEM_BACKTAB, VK_OEM_CLEAR, VK_OEM_COMMA, VK_OEM_COPY, VK_OEM_CUSEL, VK_OEM_ENLW,
-            VK_OEM_FINISH, VK_OEM_FJ_JISHO, VK_OEM_FJ_LOYA, VK_OEM_FJ_MASSHOU, VK_OEM_FJ_ROYA,
-            VK_OEM_FJ_TOUROKU, VK_OEM_JUMP, VK_OEM_MINUS, VK_OEM_NEC_EQUAL, VK_OEM_PA1, VK_OEM_PA2,
-            VK_OEM_PA3, VK_OEM_PERIOD, VK_OEM_PLUS, VK_OEM_RESET, VK_OEM_WSCTRL, VK_P, VK_PA1,
-            VK_PACKET, VK_PAUSE, VK_PLAY, VK_PRINT, VK_PROCESSKEY, VK_Q, VK_R, VK_RBUTTON,
-            VK_RETURN, VK_RSHIFT, VK_RWIN, VK_S, VK_SCROLL, VK_SELECT, VK_SEPARATOR, VK_SHIFT,
-            VK_SLEEP, VK_SPACE, VK_SUBTRACT, VK_T, VK_TAB, VK_U, VK_V, VK_VOLUME_DOWN,
-            VK_VOLUME_MUTE, VK_VOLUME_UP, VK_W, VK_X, VK_XBUTTON1, VK_XBUTTON2, VK_Y, VK_Z,
-            VK_ZOOM,
+            VK_NUMPAD7, VK_NUMPAD8, VK_NUMPAD9, VK_O, VK_OEM_1, VK_OEM_2, VK_OEM_3, VK_OEM_4,
+            VK_OEM_5, VK_OEM_6, VK_OEM_7, VK_OEM_8, VK_OEM_102, VK_OEM_ATTN, VK_OEM_AUTO,
+            VK_OEM_AX, VK_OEM_BACKTAB, VK_OEM_CLEAR, VK_OEM_COMMA, VK_OEM_COPY, VK_OEM_CUSEL,
+            VK_OEM_ENLW, VK_OEM_FINISH, VK_OEM_FJ_JISHO, VK_OEM_FJ_LOYA, VK_OEM_FJ_MASSHOU,
+            VK_OEM_FJ_ROYA, VK_OEM_FJ_TOUROKU, VK_OEM_JUMP, VK_OEM_MINUS, VK_OEM_NEC_EQUAL,
+            VK_OEM_PA1, VK_OEM_PA2, VK_OEM_PA3, VK_OEM_PERIOD, VK_OEM_PLUS, VK_OEM_RESET,
+            VK_OEM_WSCTRL, VK_P, VK_PA1, VK_PACKET, VK_PAUSE, VK_PLAY, VK_PRINT, VK_PROCESSKEY,
+            VK_Q, VK_R, VK_RBUTTON, VK_RETURN, VK_RSHIFT, VK_RWIN, VK_S, VK_SCROLL, VK_SELECT,
+            VK_SEPARATOR, VK_SHIFT, VK_SLEEP, VK_SPACE, VK_SUBTRACT, VK_T, VK_TAB, VK_U, VK_V,
+            VK_VOLUME_DOWN, VK_VOLUME_MUTE, VK_VOLUME_UP, VK_W, VK_X, VK_XBUTTON1, VK_XBUTTON2,
+            VK_Y, VK_Z, VK_ZOOM,
         };
 
         let known_ordinary_keys = [

--- a/tests/common/enigo_test.rs
+++ b/tests/common/enigo_test.rs
@@ -11,8 +11,8 @@ use enigo::{
 use super::browser_events::BrowserEvent;
 
 const TIMEOUT: u64 = 5; // Number of minutes the test is allowed to run before timing out
-                        // This is needed, because some of the websocket functions are blocking and
-                        // would run indefinitely without a timeout if they don't receive a message
+// This is needed, because some of the websocket functions are blocking and
+// would run indefinitely without a timeout if they don't receive a message
 const INPUT_DELAY: u64 = 40; // Number of milliseconds to wait for the input to have an effect
 const SCROLL_STEP: (i32, i32) = (20, 114); // (horizontal, vertical)
 


### PR DESCRIPTION
The new Rust edition `2024` was released. In order to use it, the MSRV had to be bumped to 1.85.

The Drop behavior of temporary values was changed. I was notified that the Drop behavior in the libei code was affected by this. For more, see https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html