### PR TITLE
Linux: Wayland: Fix moving the mouse to an absolute coordinate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - linux: wayland: Fix the serial number of input_method events
 - linux: wayland: Correct whitespace and nullbyte at the end of the keymap
 - linux: wayland: Send messages in the correct order and make sure Wayland objects are created before they are used
+- linux: wayland: Fix moving the mouse to an absolute coordinate
 
 # 0.3.0
 ## Changed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - win: Helper function to tell Windows to respect the users scaling settings `set_dpi_awareness`. Read the docs before using it
 - linux: Add support for numpad keys (e.g. `Key::Numpad2`)
 - macOS: Add support for numpad keys (e.g. `Key::Numpad2`)
+- linux: wayland: Implement `main_display()`. It only works reliably if only one screen is connected
 
 ## Removed
 

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -889,11 +889,16 @@ impl Mouse for Con {
     }
 
     fn main_display(&self) -> InputResult<(i32, i32)> {
-        // TODO Implement this
-        error!(
-            "You tried to get the dimensions of the main display. I don't know how this is possible under Wayland. Let me know if there is a new protocol"
-        );
-        Err(InputError::Simulate("Not implemented yet"))
+        // TODO: The assumption here is that the output we store in the first position
+        // is the main display. This likely can be wrong
+        match self.state.outputs.first() {
+            // Switch width and height if the output was transformed
+            Some((_, output_info)) if output_info.transform => {
+                Ok((output_info.height, output_info.width))
+            }
+            Some((_, output_info)) => Ok((output_info.width, output_info.height)),
+            None => Err(InputError::Simulate("No screens available")),
+        }
     }
 
     fn location(&self) -> InputResult<(i32, i32)> {

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -662,7 +662,7 @@ impl Dispatch<wl_output::WlOutput, ()> for WaylandState {
                     {
                         output_data.transform = true;
                     }
-                };
+                }
             }
             wl_output::Event::Mode {
                 flags,
@@ -678,12 +678,12 @@ impl Dispatch<wl_output::WlOutput, ()> for WaylandState {
                         output_data.width = width;
                         output_data.height = height;
                     }
-                };
+                }
             }
             ev => {
                 warn!("{ev:?}");
             }
-        };
+        }
     }
 }
 
@@ -838,6 +838,13 @@ impl Mouse for Con {
                 vp.motion(time, x as f64, y as f64);
             }
             Coordinate::Abs => {
+                let (x_extend, y_extend) = self.main_display()?;
+                let x_extend: u32 = x_extend
+                    .try_into()
+                    .map_err(|_| InputError::InvalidInput("x_extend cannot be negative"))?;
+                let y_extend: u32 = y_extend
+                    .try_into()
+                    .map_err(|_| InputError::InvalidInput("y_extend cannot be negative"))?;
                 let x: u32 = x.try_into().map_err(|_| {
                     InputError::InvalidInput("the absolute coordinates cannot be negative")
                 })?;
@@ -845,14 +852,8 @@ impl Mouse for Con {
                     InputError::InvalidInput("the absolute coordinates cannot be negative")
                 })?;
 
-                trace!("vp.motion_absolute({time}, {x}, {y}, u32::MAX, u32::MAX)");
-                vp.motion_absolute(
-                    time,
-                    x,
-                    y,
-                    u32::MAX, // TODO: Check what would be the correct value here
-                    u32::MAX, // TODO: Check what would be the correct value here
-                );
+                trace!("vp.motion_absolute({time}, {x}, {y}, {x_extend}, {y_extend})");
+                vp.motion_absolute(time, x, y, x_extend, y_extend);
             }
         }
         vp.frame(); // TODO: Check if this is needed


### PR DESCRIPTION
Implement `main_display()`. This only works correctly if there is only one screen attached, because otherwise the main screen might not be the first entry in the `Vec` we store the `WlOutput`s when getting notified about them.

Moving the mouse to an absolute location did not work, because it expects the screen dimensions in the call and we just used `u32::Max` before. Now we use the result of the `main_display` function. Since that function now works but with caveats, the same issues exist in the `move_mouse` function. For everyone with only one screen this is an improvement though.

Fixes https://github.com/enigo-rs/enigo/issues/396