### PR TITLE
linux: wayland: Sync the state of the compositor when establishing a connection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 - linux: wayland: Correct whitespace and nullbyte at the end of the keymap
 - linux: wayland: Send messages in the correct order and make sure Wayland objects are created before they are used
 - linux: wayland: Fix moving the mouse to an absolute coordinate
+- linux: wayland: Don't hang when using Sway
 
 # 0.3.0
 ## Changed


### PR DESCRIPTION
The previous implementation was very sequential and blocked multiple times until it received an event from the compositor. This lead to infinite hangs on some compositors (see https://github.com/enigo-rs/enigo/issues/396). These cases were replaced with calls to synchronize the compositor with the client. Now the library will only freeze, if the compositor never sends a "Done" event to signal that the states are synchronized. These cases would be bugs in the compositors code though.

This PR is currently based on PR https://github.com/enigo-rs/enigo/pull/402, so that one should get merged first