### PR TITLE
tests: Have Firefox return the "code" of the key

### DIFF
--- a/tests/common/browser_events.rs
+++ b/tests/common/browser_events.rs
@@ -1,3 +1,4 @@
+use enigo::{Direction, Key};
 use serde::{Deserialize, Serialize};
 use tungstenite::{Message, Utf8Bytes};
 
@@ -46,6 +47,53 @@ impl TryFrom<Message> for BrowserEvent {
                 println!("Other Message received");
                 Err(BrowserEventError::UnknownMessageType)
             }
+        }
+    }
+}
+
+impl PartialEq<(Key, Direction)> for BrowserEvent {
+    fn eq(&self, (key, direction): &(Key, Direction)) -> bool {
+        match self {
+            BrowserEvent::KeyDown(name) if *direction == Direction::Press => {
+                let key_name = match key {
+                    Key::Unicode(char) => format!("{char}"),
+                    Key::Shift => format!("ShiftLeft"),
+                    Key::LShift => format!("ShiftLeft"),
+                    Key::RShift => format!("ShiftRight"),
+                    Key::Control => format!("ControlLeft"),
+                    Key::LControl => format!("ControlLeft"),
+                    Key::RControl => format!("ControlRight"),
+                    // TODO: Add the other keys that have a right and left variant here
+                    _ => format!("{key:?}"),
+                };
+                key_name == *name
+            }
+
+            BrowserEvent::KeyUp(name) if *direction == Direction::Release => {
+                let key_name = match key {
+                    Key::Unicode(char) => format!("{char}"),
+                    Key::Shift => format!("ShiftLeft"),
+                    Key::LShift => format!("ShiftLeft"),
+                    Key::RShift => format!("ShiftRight"),
+                    Key::Control => format!("ControlLeft"),
+                    Key::LControl => format!("ControlLeft"),
+                    Key::RControl => format!("ControlRight"),
+                    // TODO: Add the other keys that have a right and left variant here
+                    _ => format!("{key:?}"),
+                };
+                key_name == *name
+            }
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<&str> for BrowserEvent {
+    fn eq(&self, other: &&str) -> bool {
+        if let BrowserEvent::Text(received_text) = self {
+            other == received_text
+        } else {
+            false
         }
     }
 }

--- a/tests/common/enigo_test.rs
+++ b/tests/common/enigo_test.rs
@@ -93,12 +93,7 @@ impl Keyboard for EnigoTest {
         self.send_message("GetText");
 
         let ev = self.read_message();
-        if let BrowserEvent::Text(received_text) = ev {
-            println!("received text: {received_text}");
-            assert_eq!(text, received_text);
-        } else {
-            panic!("BrowserEvent was not a Text: {ev:?}");
-        }
+        assert_eq!(ev, text);
 
         res.map(Some) // TODO: Check if this is always correct
     }
@@ -107,34 +102,12 @@ impl Keyboard for EnigoTest {
         let res = self.enigo.key(key, direction);
         if direction == Press || direction == Click {
             let ev = self.read_message();
-            if let BrowserEvent::KeyDown(name) = ev {
-                println!("received pressed key: {name}");
-                let key_name = if let Key::Unicode(char) = key {
-                    format!("{char}")
-                } else {
-                    format!("{key:?}").to_lowercase()
-                };
-                println!("key_name: {key_name}");
-                assert_eq!(key_name, name.to_lowercase());
-            } else {
-                panic!("BrowserEvent was not a KeyDown: {ev:?}");
-            }
+            assert_eq!(ev, (key, Press))
         }
         if direction == Release || direction == Click {
             std::thread::sleep(std::time::Duration::from_millis(INPUT_DELAY)); // Wait for input to have an effect
             let ev = self.read_message();
-            if let BrowserEvent::KeyUp(name) = ev {
-                println!("received released key: {name}");
-                let key_name = if let Key::Unicode(char) = key {
-                    format!("{char}")
-                } else {
-                    format!("{key:?}").to_lowercase()
-                };
-                println!("key_name: {key_name}");
-                assert_eq!(key_name, name.to_lowercase());
-            } else {
-                panic!("BrowserEvent was not a KeyUp: {ev:?}");
-            }
+            assert_eq!(ev, (key, Release));
         }
         println!("enigo.key() was a success");
         res

--- a/tests/index.html
+++ b/tests/index.html
@@ -157,14 +157,14 @@
         // Handle keydown events but ignore if flag is set
         document.addEventListener('keydown', (event) => {
             if (!ignoreKeyEvents) {
-                handleEvent('KeyDown', `(\"${event.key}\")`);
+                handleEvent('KeyDown', `(\"${event.code}\")`);
             }
         });
 
         // Handle keyup events but ignore if flag is set
         document.addEventListener('keyup', (event) => {
             if (!ignoreKeyEvents) {
-                handleEvent('KeyUp', `(\"${event.key}\")`);
+                handleEvent('KeyUp', `(\"${event.code}\")`);
             }
         });
 

--- a/tests/integration_browser.rs
+++ b/tests/integration_browser.rs
@@ -20,6 +20,23 @@ fn integration_browser_events() {
     enigo.key(Key::Backspace, Press).unwrap();
     enigo.key(Key::Backspace, Release).unwrap();
 
+    // Skip when using xdo feature because xdotools doesn't properly simulate right
+    // modifiers
+    // https://github.com/jordansissel/xdotool/issues/487
+    #[cfg(not(feature = "xdo"))]
+    {
+        println!("Test if the left and right versions of keys can get differentiated");
+        enigo.key(Key::Control, Press).unwrap();
+        enigo.key(Key::Control, Release).unwrap();
+        enigo.key(Key::LControl, Press).unwrap();
+        enigo.key(Key::LControl, Release).unwrap();
+        enigo.key(Key::RControl, Press).unwrap();
+        enigo.key(Key::RControl, Release).unwrap();
+        enigo.key(Key::Shift, Click).unwrap();
+        enigo.key(Key::LShift, Click).unwrap();
+        enigo.key(Key::RShift, Click).unwrap();
+    }
+
     println!("Test mouse");
     // enigo.button(Button::Left, Click).unwrap();
     enigo.move_mouse(100, 100, Abs).unwrap();


### PR DESCRIPTION
If Firefox returns the event.key, we cannot differentiate between for example a left and a right shift.

The added tests help to prevent regressions on https://github.com/enigo-rs/enigo/issues/391