### PR TITLE
linux: x11rb: Don't assume a modifier mapping and get the modifier mapping dynamically instead

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@
 - linux: wayland: Fix moving the mouse to an absolute coordinate
 - linux: wayland: Don't hang when using Sway
 - linux: x11rb: Fix not being able to enter right modifier keys [#391](https://github.com/enigo-rs/enigo/issues/391)
+- linux: x11rb: Don't assume a modifier mapping and get the modifier mapping dynamically instead [#410](https://github.com/enigo-rs/enigo/issues/410)
 
 # 0.3.0
 ## Changed


### PR DESCRIPTION
We previously hard-coded the modifier mapping. This is not the correct way to do it. It always depends on the keymap of the user. We don't even have to mess with the modifiers with X11, since it's all taken care of by the compositor. I left it in the code for now, but might remove it later.

Fixes the x11rb part of https://github.com/enigo-rs/enigo/issues/410