### PR TITLE
linux: Never use keycode 8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 - linux: wayland: Don't hang when using Sway
 - linux: x11rb: Fix not being able to enter right modifier keys [#391](https://github.com/enigo-rs/enigo/issues/391)
 - linux: x11rb: Don't assume a modifier mapping and get the modifier mapping dynamically instead [#410](https://github.com/enigo-rs/enigo/issues/410)
+- linux: x11rb: Successfully enter the first simulated character as well
 
 # 0.3.0
 ## Changed

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -92,7 +92,12 @@ impl Con {
             8,
             255,
             // All keycodes are unused when initialized
-            (8..=255).collect::<VecDeque<Keycode>>(),
+            // Never use keycode 8
+            // Keycode 8 is special: when converted to evdev keycodes,
+            // 8 is subtracted, resulting in 0. This typically leads to no effect
+            // when simulating input because keycode 0 corresponds to NoSymbol,
+            // meaning it has no assigned key mapping.
+            (9..=255).collect::<VecDeque<Keycode>>(),
             0,
             Vec::new(),
         );

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -145,7 +145,12 @@ impl Con {
                 trace!("{kc}:  {syms_name:?}");
             }
 
-            if syms.iter().all(|&s| s == Keysym::NoSymbol.raw()) {
+            // Never use keycode 8
+            // Keycode 8 is special: when converted to evdev keycodes,
+            // 8 is subtracted, resulting in 0. This typically leads to no effect
+            // when simulating input because keycode 0 corresponds to NoSymbol,
+            // meaning it has no assigned key mapping.
+            if syms.iter().all(|&s| s == Keysym::NoSymbol.raw()) && kc != 8 {
                 unused_keycodes.push_back(kc);
             }
         }


### PR DESCRIPTION
Keycode 8 is special: when converted to evdev keycodes, 8 is subtracted, resulting in 0. This typically leads to no effect when simulating input because keycode 0 corresponds to NoSymbol, meaning it has no assigned key mapping.