### PR TITLE
CI: Add env variables to see log messages

### DIFF
--- a/.github/actions/screenshot/action.yml
+++ b/.github/actions/screenshot/action.yml
@@ -1,0 +1,46 @@
+name: "screenshot"
+description: "Creates a screenshot"
+inputs:
+  rust:
+    description: 'Name of the Rust version'     
+    required: true
+  platform:
+    description: 'Name of the OS'     
+    required: true
+  feature:
+    description: 'Activated features'     
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Echo inputs
+      shell: bash
+      run: echo "${{ inputs.platform }}_${{ inputs.rust }}_${{ inputs.feature }}"
+    - name: Take screenshot on Linux
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get install -y imagemagick
+        DISPLAY=$DISPLAY import -window root -quality 90 ./'${{ inputs.platform }}_${{ inputs.rust }}_${{ inputs.feature }}.jpg'
+    - name: Take screenshot on macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        screencapture -x "${{ inputs.platform }}_${{ inputs.rust }}_${{ inputs.feature }}.jpg"
+    - name: Take screenshot on Windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        Add-Type -AssemblyName System.Windows.Forms, System.Drawing
+        $bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+        $bitmap = New-Object System.Drawing.Bitmap $bounds.Width, $bounds.Height
+        $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+        $graphics.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size)
+        $bitmap.Save("${{ inputs.platform }}_${{ inputs.rust }}_${{ inputs.feature }}.jpg", [System.Drawing.Imaging.ImageFormat]::Jpeg)
+    - uses: actions/upload-artifact@v4
+      with:
+        name: '${{ inputs.platform }}_${{ inputs.rust }}_${{ inputs.feature }}.jpg'
+        path: '${{ inputs.platform }}_${{ inputs.rust }}_${{ inputs.feature }}.jpg'
+        overwrite: true
+        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUST_LOG: debug
+  WAYLAND_DEBUG: 1
 
 jobs:
   build:

--- a/.github/workflows/failing_tests.yml
+++ b/.github/workflows/failing_tests.yml
@@ -12,6 +12,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUST_LOG: debug
+  WAYLAND_DEBUG: 1
 
 jobs:
   additional_tests:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -80,3 +80,11 @@ jobs:
       - name: Run integration tests in release mode
         if: matrix.features != 'wayland' && matrix.features != 'libei' && matrix.features != 'libei,wayland,xdo,x11rb' # On Linux, the integration tests only work with X11 for now
         run: cargo test integration --release --no-default-features --features ${{ matrix.features }} -- --test-threads=1 --nocapture --include-ignored
+
+      - name: Take screenshot
+        if: always()
+        uses: ./.github/actions/screenshot
+        with:
+          platform: ${{ matrix.platform }}
+          rust: ${{ matrix.rust }}
+          feature: ${{ matrix.features }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUST_LOG: debug
+  WAYLAND_DEBUG: 1
 
 jobs:
   integration:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUST_LOG: debug
+  WAYLAND_DEBUG: 1
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ On Gentoo:
 emerge -a xdotool
 ```
 
+## Permissions
+
+Some platforms have security measures in place to prevent programs from entering keys or controlling the mouse. Have a look at the [permissions](Permissions.md) documentation to see what you need to do to allow it.
+
 ## Migrating from a previous version
 
 Please have a look at our [changelog](CHANGES.md) to find out what you have to do, if you used a previous version.
@@ -76,6 +80,11 @@ Please have a look at our [changelog](CHANGES.md) to find out what you have to d
 
 If you encounter an issue and want to debug it, turn on log messages as described [here](DEBUGGING.md).
 
-## Permissions
 
-Some platforms have security measures in place to prevent programs from entering keys or controlling the mouse. Have a look at the [permissions](Permissions.md) documentation to see what you need to do to allow it.
+## Testing this crate
+
+*Warning*: The tests will move the mouse, enter text, press keys and open some applications. Read the test cases before you run them so you know what to expect. It's best to close everything so that the tests don't mess with your system. Some of them run for a long time because they are intended to be run in the CI. Make sure to run the tests sequentially, otherwise they will fail because other mouse movements or entered keys are detected. You can do so by running
+
+```Bash
+cargo test --all-features -- --test-threads=1
+```


### PR DESCRIPTION
On Linux, there are messages sent to the compositor using X11 or Wayland messages. In order to debug errors and failed tests, it's very beneficial to see the messages and log messages. This PR sets the correct environment variables to have the output printed with Wayland.

I tried to use xtrace to print the X11 messages as well, but it was too difficult to add to the CI