### PR TITLE
linux: x11rb: Test scroll function as well

### DIFF
--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -441,22 +441,17 @@ impl Mouse for Con {
     }
 
     fn scroll(&mut self, length: i32, axis: Axis) -> InputResult<()> {
-        let mut length = length;
-        let button = if length < 0 {
-            length = -length;
-            match axis {
-                Axis::Horizontal => Button::ScrollLeft,
-                Axis::Vertical => Button::ScrollUp,
-            }
-        } else {
-            match axis {
-                Axis::Horizontal => Button::ScrollRight,
-                Axis::Vertical => Button::ScrollDown,
-            }
+        let button = match (length.is_positive(), axis) {
+            (true, Axis::Vertical) => Button::ScrollDown,
+            (false, Axis::Vertical) => Button::ScrollUp,
+            (true, Axis::Horizontal) => Button::ScrollRight,
+            (false, Axis::Horizontal) => Button::ScrollLeft,
         };
-        for _ in 0..length {
+
+        for _ in 0..length.abs() {
             self.button(button, Direction::Click)?;
         }
+
         Ok(())
     }
 

--- a/src/linux/xdo.rs
+++ b/src/linux/xdo.rs
@@ -281,20 +281,14 @@ impl Mouse for Con {
     }
 
     fn scroll(&mut self, length: i32, axis: Axis) -> InputResult<()> {
-        let mut length = length;
-        let button = if length < 0 {
-            length = -length;
-            match axis {
-                Axis::Horizontal => Button::ScrollLeft,
-                Axis::Vertical => Button::ScrollUp,
-            }
-        } else {
-            match axis {
-                Axis::Horizontal => Button::ScrollRight,
-                Axis::Vertical => Button::ScrollDown,
-            }
+        let button = match (length.is_positive(), axis) {
+            (true, Axis::Vertical) => Button::ScrollDown,
+            (false, Axis::Vertical) => Button::ScrollUp,
+            (true, Axis::Horizontal) => Button::ScrollRight,
+            (false, Axis::Horizontal) => Button::ScrollLeft,
         };
-        for _ in 0..length {
+
+        for _ in 0..length.abs() {
             self.button(button, Direction::Click)?;
         }
         Ok(())

--- a/src/tests/keyboard.rs
+++ b/src/tests/keyboard.rs
@@ -157,7 +157,7 @@ fn unit_key_other_all_keycodes() {
     }
 
     // This will only run on Windows
-    for raw_keycode in max..=max {
+    for raw_keycode in max..=u32::MAX {
         assert_eq!(
             enigo.key(Key::Other(raw_keycode), Press),
             Err(InputError::InvalidInput(

--- a/src/tests/mouse.rs
+++ b/src/tests/mouse.rs
@@ -233,13 +233,19 @@ fn unit_10th_click() {
     }
 }
 
-#[cfg(not(feature = "x11rb"))] // For some reason it stalls
 #[test]
 fn unit_scroll() {
     let delay = super::get_delay();
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
 
-    let test_cases = vec![0, 1, 5, 100, 57899, -57899, -0, -1, -5, -100];
+    // On X11 there is no scroll function but instead we repeatedly simulate a
+    // keypress. This takes a long time for large values. That's why we skip them on
+    // X11
+    let test_cases = if cfg!(any(feature = "xdo", feature = "x11rb")) {
+        vec![0, 1, 5, 100, -0, -1, -5, -100]
+    } else {
+        vec![0, 1, 5, 100, 57899, -57899, -0, -1, -5, -100]
+    };
 
     for length in &test_cases {
         thread::sleep(delay);


### PR DESCRIPTION
The CI tests used to time out for x11rb. I thought they stalled, but when I ran them locally, I noticed that they just take a very long time. On X11 there is no scroll function but instead we have to repeatedly simulate a key press. This takes a long time for large values. That's why we skip the huge values on X11.

The integration tests hang for windows and macos so they have not been enabled