### PR TITLE
CI: Add more info about keys

### DIFF
--- a/tests/common/browser_events.rs
+++ b/tests/common/browser_events.rs
@@ -1,4 +1,5 @@
 use enigo::{Direction, Key};
+use log::debug;
 use serde::{Deserialize, Serialize};
 use tungstenite::{Message, Utf8Bytes};
 
@@ -6,8 +7,8 @@ use tungstenite::{Message, Utf8Bytes};
 pub enum BrowserEvent {
     ReadyForText,
     Text(String),
-    KeyDown(String),
-    KeyUp(String),
+    KeyDown(String, String),
+    KeyUp(String, String),
     MouseDown(u32),
     MouseUp(u32),
     MouseMove((i32, i32), (i32, i32)), // (relative, absolute)
@@ -32,14 +33,14 @@ impl TryFrom<Message> for BrowserEvent {
                 Ok(BrowserEvent::Close)
             }
             Message::Text(msg) => {
-                println!("Message::Text received");
+                println!("Browser received input");
                 println!("msg: {msg:?}");
 
                 // Attempt to deserialize the text message into a BrowserEvent
                 if let Ok(event) = ron::from_str::<BrowserEvent>(&msg) {
                     Ok(event)
                 } else {
-                    println!("Parse error");
+                    println!("Parse error! Message: {msg}");
                     Err(BrowserEventError::ParseError)
                 }
             }
@@ -54,7 +55,7 @@ impl TryFrom<Message> for BrowserEvent {
 impl PartialEq<(Key, Direction)> for BrowserEvent {
     fn eq(&self, (key, direction): &(Key, Direction)) -> bool {
         match self {
-            BrowserEvent::KeyDown(name) if *direction == Direction::Press => {
+            BrowserEvent::KeyDown(name, debug_data) if *direction == Direction::Press => {
                 let key_name = match key {
                     Key::Unicode(char) => format!("{char}"),
                     Key::Shift => format!("ShiftLeft"),
@@ -66,10 +67,15 @@ impl PartialEq<(Key, Direction)> for BrowserEvent {
                     // TODO: Add the other keys that have a right and left variant here
                     _ => format!("{key:?}"),
                 };
-                key_name == *name
+                if key_name == *name {
+                    true
+                } else {
+                    debug!("key debug data: {debug_data}");
+                    false
+                }
             }
 
-            BrowserEvent::KeyUp(name) if *direction == Direction::Release => {
+            BrowserEvent::KeyUp(name, debug_data) if *direction == Direction::Release => {
                 let key_name = match key {
                     Key::Unicode(char) => format!("{char}"),
                     Key::Shift => format!("ShiftLeft"),
@@ -81,7 +87,12 @@ impl PartialEq<(Key, Direction)> for BrowserEvent {
                     // TODO: Add the other keys that have a right and left variant here
                     _ => format!("{key:?}"),
                 };
-                key_name == *name
+                if key_name == *name {
+                    true
+                } else {
+                    debug!("{debug_data}");
+                    false
+                }
             }
             _ => false,
         }
@@ -114,12 +125,18 @@ fn deserialize_browser_events() {
             BrowserEvent::Text("Hi how are you?❤️ äüß$3".to_string()),
         ),
         (
-            Message::Text(Utf8Bytes::from("KeyDown(\"F11\")")),
-            BrowserEvent::KeyDown("F11".to_string()),
+            Message::Text(Utf8Bytes::from("KeyDown(\"F11\", \"\")")),
+            BrowserEvent::KeyDown("F11".to_string(), "".to_string()),
         ),
         (
-            Message::Text(Utf8Bytes::from("KeyUp(\"F11\")")),
-            BrowserEvent::KeyUp("F11".to_string()),
+            Message::Text(Utf8Bytes::from("KeyUp(\"F11\", \"\")")),
+            BrowserEvent::KeyUp("F11".to_string(), "".to_string()),
+        ),
+        (
+            Message::Text(Utf8Bytes::from(
+                "KeyDown(\"F1\", \"key: F1, which: 112, charCode: 0, shiftKey: false, ctrlKey: false, altKey: false, metaKey: false, repeat: false, isComposing: false, location: 0, bubbles: true, cancelable: true, defaultPrevented: false, composed: true\")",
+            )),
+            BrowserEvent::KeyDown("F1".to_string(),  "key: F1, which: 112, charCode: 0, shiftKey: false, ctrlKey: false, altKey: false, metaKey: false, repeat: false, isComposing: false, location: 0, bubbles: true, cancelable: true, defaultPrevented: false, composed: true".to_string()),
         ),
         (
             Message::Text(Utf8Bytes::from("MouseDown(0)")),
@@ -143,6 +160,6 @@ fn deserialize_browser_events() {
         let serialized = ron::to_string(&event).unwrap();
         println!("serialized = {serialized}");
 
-        assert!(BrowserEvent::try_from(msg).unwrap() == event);
+        assert_eq!(BrowserEvent::try_from(msg).unwrap(), event);
     }
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -157,14 +157,20 @@
         // Handle keydown events but ignore if flag is set
         document.addEventListener('keydown', (event) => {
             if (!ignoreKeyEvents) {
-                handleEvent('KeyDown', `(\"${event.code}\")`);
+
+                let debug_data = `key: ${event.key}, which: ${event.which}, charCode: ${event.charCode}, shiftKey: ${event.shiftKey}, ctrlKey: ${event.ctrlKey}, altKey: ${event.altKey}, metaKey: ${event.metaKey}, repeat: ${event.repeat}, isComposing: ${event.isComposing}, location: ${event.location}, bubbles: ${event.bubbles}, cancelable: ${event.cancelable}, defaultPrevented: ${event.defaultPrevented}, composed: ${event.composed}`;
+
+                handleEvent('KeyDown', `(\"${event.code}\", \"${debug_data}\")`);
             }
         });
 
         // Handle keyup events but ignore if flag is set
         document.addEventListener('keyup', (event) => {
             if (!ignoreKeyEvents) {
-                handleEvent('KeyUp', `(\"${event.code}\")`);
+
+                let debug_data = `key: ${event.key}, which: ${event.which}, charCode: ${event.charCode}, shiftKey: ${event.shiftKey}, ctrlKey: ${event.ctrlKey}, altKey: ${event.altKey}, metaKey: ${event.metaKey}, repeat: ${event.repeat}, isComposing: ${event.isComposing}, location: ${event.location}, bubbles: ${event.bubbles}, cancelable: ${event.cancelable}, defaultPrevented: ${event.defaultPrevented}, composed: ${event.composed}`;
+
+                handleEvent('KeyUp', `(\"${event.code}\", \"${debug_data}\")`);
             }
         });
 


### PR DESCRIPTION
I also tried to use `event.keyCode` to test `enigo.raw`, but the keycodes don't match. I don't understand why, but they are completely different.