### PR TITLE
linux: libei improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ env:
   RUST_BACKTRACE: 1
   RUST_LOG: debug
   WAYLAND_DEBUG: 1
+  REIS_DEBUG: 1
 
 jobs:
   build:

--- a/.github/workflows/failing_tests.yml
+++ b/.github/workflows/failing_tests.yml
@@ -14,6 +14,7 @@ env:
   RUST_BACKTRACE: 1
   RUST_LOG: debug
   WAYLAND_DEBUG: 1
+  REIS_DEBUG: 1
 
 jobs:
   additional_tests:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,6 +14,7 @@ env:
   RUST_BACKTRACE: 1
   RUST_LOG: debug
   WAYLAND_DEBUG: 1
+  REIS_DEBUG: 1
 
 jobs:
   integration:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ env:
   RUST_BACKTRACE: 1
   RUST_LOG: debug
   WAYLAND_DEBUG: 1
+  REIS_DEBUG: 1
 
 jobs:
   test:

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -1,7 +1,7 @@
 # TL;DR: Log everything (except X11)
 
 ```
-RUST_LOG=debug WAYLAND_DEBUG=1 cargo run --example keyboard
+RUST_LOG=debug WAYLAND_DEBUG=1 REIS_DEBUG=1 cargo run --example keyboard
 ```
 
 # Debugging
@@ -22,6 +22,9 @@ RUST_LOG=enigo::platform::x11=debug cargo run --example keyboard --features x11r
 
 On Linux, we can additionally print the messages that are exchanged with the compositor. It depends on the used protocol how to turn this on.
 
+### Libei
+Run the executable with the environment variable `REIS_DEBUG=1`.
+
 ### Wayland
 Run the executable with the environment variable `WAYLAND_DEBUG=1`.
 
@@ -40,5 +43,5 @@ cargo run
 ## Log everything (including X11)
 
 ```
-RUST_LOG=debug WAYLAND_DEBUG=1 /home/pentamassiv/x11rb/target/debug/xtrace-example cargo run --example keyboard --features x11rb,wayland --no-default-features
+RUST_LOG=debug WAYLAND_DEBUG=1 REIS_DEBUG=1 /home/pentamassiv/x11rb/target/debug/xtrace-example cargo run --example keyboard --features x11rb,wayland --no-default-features
 ```

--- a/src/linux/libei.rs
+++ b/src/linux/libei.rs
@@ -189,7 +189,7 @@ impl Con {
             // && device_data.interface::<ei::Keyboard>().is_some()
         }) {
             println!("Start emulating");
-            device.start_emulating(con.sequence, con.last_serial);
+            device.start_emulating(con.last_serial, con.sequence);
             con.sequence = con.sequence.wrapping_add(1);
             device_data.state = DeviceState::Emulating;
         }


### PR DESCRIPTION
This PR contains the following three improvements:

[linux: libei: Send frame request for press and release of key](https://github.com/enigo-rs/enigo/commit/f354894f60c5ab0b227ff55e5344aed927968078)
It is a client bug to send more than one key request for the same key within the same ei_device.frame and the EIS implementation may ignore either or all key state changes and/or disconnect the client. (source https://libinput.pages.freedesktop.org/libei/interfaces/ei_keyboard/index.html#ei_keyboardkey)

[linux: libei: Fix mixed up argument order when calling start_emulating](https://github.com/enigo-rs/enigo/commit/e09ddea8d53a0a9ab477d0a2ab1226924735daa5)

[linux: libei: Add information about debugging with libei](https://github.com/enigo-rs/enigo/commit/d4b81b71901b187db3433c3a1a3ac18a47eedf7d)
To see the events sent and received via libei, the env variable REIS_DEBUG must be set. We now also set it in the Github Workflows