### PR TITLE
linux: wayland: Fix the release of a raw key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 ## Removed
 
 ## Fixed
+- linux: wayland: Fix releasing raw keys
 
 # 0.4.0
 ## Changed

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -852,7 +852,7 @@ impl Keyboard for Con {
                     effective_layout_new,
                 )?;
             } else {
-                self.send_key_event(keycode.into(), Direction::Press)?;
+                self.send_key_event(keycode.into(), Direction::Release)?;
             }
         }
         Ok(())


### PR DESCRIPTION
I had a typo. The key was never released.