### PR TITLE
linux: wayland: Don't try to use the input_method protocol if it is unavailable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 
 ## Fixed
 - linux: wayland: Fix releasing raw keys
+- linux: wayland: Don't try to use the input_method protocol if it is unavailable
 
 # 0.4.0
 ## Changed

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -445,8 +445,15 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
 
                 match &interface[..] {
                     "wl_seat" => {
-                        state.im_manager = None;
+                        state.virtual_keyboard = None;
                         state.keyboard_manager = None;
+                        state.input_method = None;
+                        state.im_manager = None;
+                        state.virtual_pointer = None;
+                        state.pointer_manager = None;
+                        state.seat_keyboard = None;
+                        state.seat_keymap = None;
+                        state.seat_pointer = None;
                         state.seat = None;
                     }
                     "wl_output" => {
@@ -455,13 +462,16 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                             .retain(|(output, _)| output.id().protocol_id() != *name);
                     }
                     "zwp_input_method_manager_v2" => {
+                        state.input_method = None;
                         state.im_manager = None;
                     }
                     "zwp_virtual_keyboard_manager_v1" => {
+                        state.virtual_keyboard = None;
                         state.keyboard_manager = None;
                     }
                     "zwlr_virtual_pointer_manager_v1" => {
                         state.pointer_manager = None;
+                        state.virtual_pointer = None;
                     }
                     _ => {}
                 }

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -533,9 +533,16 @@ impl Dispatch<zwp_input_method_v2::ZwpInputMethodV2, ()> for WaylandState {
             | zwp_input_method_v2::Event::ContentType {
                 hint: _,
                 purpose: _,
-            }
-            | zwp_input_method_v2::Event::Unavailable => {
+            } => {
                 trace!("ZwpInputMethodV2 received irrelevant event:\n{event:?}");
+            }
+            zwp_input_method_v2::Event::Unavailable => {
+                warn!("ZwpInputMethodV2 received event:\nzwp_input_method_v2::Event::Unavailable");
+                warn!(
+                    "It is not possible to enter text anymore! The characters will now be simulated by individual key presses instead"
+                );
+                state.input_method = None;
+                state.im_manager = None;
             }
             _ => warn!("ZwpInputMethodV2 received unknown event:\n{event:?}"),
         }

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -341,6 +341,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                             if state.input_method.is_none() {
                                 let input_method = im_manager.get_input_method(&seat, qh, ());
                                 state.input_method = Some(input_method);
+                                state.im_serial = Wrapping(0u32);
                             }
                         }
                         // We don't know if the seat or the keyboard_manager is created first and we
@@ -383,6 +384,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                             if state.input_method.is_none() {
                                 let input_method = im_manager.get_input_method(seat, qh, ());
                                 state.input_method = Some(input_method);
+                                state.im_serial = Wrapping(0u32);
                             }
                         }
                         state.im_manager = Some(im_manager);


### PR DESCRIPTION
There can only be one input method. If there already is one present, the compositor will send a "Unavailable" event and ignore all messages related to it.
Fixes https://github.com/enigo-rs/enigo/issues/444