### PR TITLE
linux: Fix the names of the keysyms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 ## Removed
 
 ## Fixed
+-linux: xdo: Enable entering all unicode characters with the `key` function
+-linux: wayland: Enable entering all unicode characters with the `key` function
 
 # 0.4.1
 ## Changed

--- a/src/linux/keymap.rs
+++ b/src/linux/keymap.rs
@@ -283,7 +283,6 @@ where
     pub fn regenerate(&mut self) -> Result<Option<u32>, std::io::Error> {
         use super::{KEYMAP_BEGINNING, KEYMAP_END};
         use std::io::{Seek, SeekFrom, Write};
-        use xkbcommon::xkb::keysym_get_name;
 
         // Don't do anything if there were no changes
         if !self.keymap_state.needs_regeneration {
@@ -312,7 +311,7 @@ where
                 "
 	key <I{}>                 {{	[               {} ] }};",
                 keycode,
-                keysym_get_name(keysym)
+                format!("{keysym:?}")
             )?;
         }
         keymap_file.write_all(KEYMAP_END)?;

--- a/src/linux/keymap2/mod.rs
+++ b/src/linux/keymap2/mod.rs
@@ -241,23 +241,24 @@ impl Keymap2 {
     }
 
     pub fn key_to_keycode(&self, key: Key) -> Option<u16> {
-        let Some(key_name) = Keysym::from(key).name() else {
-            error!("the key to map doesn't have a name");
-            return None;
-        };
+        let keysym = Keysym::from(key);
+        let key_name = format!("{keysym:?}");
 
         (self.keymap.min_keycode().raw()..self.keymap.max_keycode().raw())
-            .find(|&k| self.state.key_get_one_sym(Keycode::new(k)).name() == Some(key_name))
+            .find(|&k| {
+                let keycode = Keycode::new(k);
+                let keysym = self.state.key_get_one_sym(keycode);
+                format!("{keysym:?}") == key_name
+            })
             .and_then(|k| u16::try_from(k).ok())
     }
 
     pub fn map_key(&mut self, key: Key) -> InputResult<u16> {
-        let key_name = Keysym::from(key).name().ok_or_else(|| {
-            crate::InputError::Mapping("the key to map doesn't have a name".to_string())
-        })?;
+        let keysym = Keysym::from(key);
+        let key_name = format!("{keysym:?}");
         let key_name = match key_name.strip_prefix("XK_") {
             Some(key_name) => key_name,
-            None => key_name,
+            None => &key_name,
         };
         self.parsed_keymap.map_key(key_name, true)
     }

--- a/src/linux/xdo.rs
+++ b/src/linux/xdo.rs
@@ -169,10 +169,7 @@ impl Keyboard for Con {
 
     fn key(&mut self, key: Key, direction: Direction) -> InputResult<()> {
         let keysym = Keysym::from(key);
-        let Some(keysym_name) = keysym.name() else {
-            // this should never happen, because we only use keysyms with a known name
-            return Err(InputError::InvalidInput("the keysym does not have a name"));
-        };
+        let keysym_name = format!("{keysym:?}");
         let keysym_name = keysym_name.replace("XK_", ""); // TODO: remove if xkeysym changed their names (https://github.com/rust-windowing/xkeysym/issues/18)
 
         let Ok(string) = CString::new(keysym_name) else {


### PR DESCRIPTION
The `xkeysym::name` function does not always return a name, even though each keysym does have a name. Previously it was impossible on Wayland and with the xdo feature to enter unicode keys where `name()` returned a `None`.