### PR TITLE
linux: x11: Change the default feature to x11rb

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Unreleased
 ## Changed
+- linux: x11: Use `x11rb` by default to simulate input as it is more reliable, makes it possible to enter raw keycodes, does not need `xdotools` as a runtime dependency and uses native Rust. If you experience issue with the new default, please open an issue. You can disable default features and use the feature `xdo` to use the old method.
 
 ## Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = [".github", "examples", ".gitignore", "rustfmt.toml"]
 all-features = true
 
 [features]
-default = ["xdo"]
+default = ["x11rb"]
 libei = ["dep:reis", "dep:ashpd", "dep:tokio", "dep:nom"]
 serde = ["dep:serde"]
 wayland = [

--- a/README.md
+++ b/README.md
@@ -39,12 +39,9 @@ By default, enigo currently works on Windows, macOS and Linux (X11). If you want
 
 There are multiple ways how to simulate input on Linux and not all systems support everything. Enigo can also use wayland protocols and libei to simulate input but there are currently some bugs with it. That is why they are hidden behind feature flags.
 
-If you do not want your users to have to install any runtime dependencies on Linux when using X11, you can try the experimental `x11rb` feature.
-
-
 ## Runtime dependencies
 
-Linux users may have to install `libxdo-dev` if they are using `X11`. For example, on Debian-based distros:
+Linux users may have to install `libxdo-dev` if they are using the `xdo` feature. For example, on Debian-based distros:
 
 ```Bash
 apt install libxdo-dev


### PR DESCRIPTION
It is more reliable, makes it possible to enter raw keycodes, does not need `xdotools` as a runtime dependency and uses more native Rust. If you experience issue with the new default, please open an issue. You can disable default features and use the feature `xdo` to use the old method