### PR TITLE
change scrolleventunit from line to pixel on mac

### DIFF
--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -242,7 +242,7 @@ impl Mouse for Enigo {
 
         let Ok(event) = CGEvent::new_scroll_event(
             self.event_source.clone(),
-            ScrollEventUnit::LINE,
+            ScrollEventUnit::PIXEL,
             ax,
             len_x,
             len_y,


### PR DESCRIPTION
change scrolleventunit from line to pixel on mac will get smooth scrolling experience