### PR TITLE
linux: libei: Use futures crate to not nest runtimes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 ## Removed
 
 ## Fixed
+- linux: libei: The library can now be used inside a Tokio runtime. Previously that was not possible, because it would attempt to start a runtime from within another runtime.
 
 # 0.5.0
 ## Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["x11rb"]
-libei = ["dep:reis", "dep:ashpd", "dep:tokio", "dep:nom"]
+libei = ["dep:reis", "dep:ashpd", "dep:futures", "dep:nom"]
 platform_specific = []
 serde = ["dep:serde"]
 wayland = [
@@ -75,10 +75,7 @@ foreign-types-shared = "0.3"
 libc = "0.2"
 reis = { version = "0.5", optional = true }
 ashpd = { version = "0.11", optional = true }
-tokio = { version = "1.23.1", features = [
-    "rt",
-    "rt-multi-thread",
-], optional = true }
+futures = { version = "0.3", optional = true }
 wayland-protocols-misc = { version = "0.3", features = [
     "client",
 ], optional = true }

--- a/src/linux/libei.rs
+++ b/src/linux/libei.rs
@@ -142,12 +142,8 @@ impl Con {
         let sequence = 0;
         let time_created = Instant::now();
 
-        // Initialize a Tokio runtime
-        let runtime = tokio::runtime::Runtime::new()
-            .map_err(|_| NewConError::EstablishCon("failed to create tokio runtime"))?;
-
-        // Block on an async function within this runtime
-        let context = runtime.block_on(async { Self::open_connection().await });
+        // Run the async open_connection() synchronously
+        let context = futures::executor::block_on(Self::open_connection());
 
         let HandshakeResp {
             connection,


### PR DESCRIPTION
Previously there was a panic if the library was used with another Tokio runtime because it is not possible to start a runtime from within another runtime. Fixes issue 1 in https://github.com/enigo-rs/enigo/issues/453.