### PR TITLE
linux: libei: Fix runtime crash if no tokio runtime was started

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,9 @@ foreign-types-shared = "0.3"
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 libc = "0.2"
 reis = { version = "0.5", optional = true }
-ashpd = { version = "0.11", optional = true }
+ashpd = { version = "0.11", features = [
+    "async-std",
+], default-features = false, optional = true }
 futures = { version = "0.3", optional = true }
 wayland-protocols-misc = { version = "0.3", features = [
     "client",


### PR DESCRIPTION
The previous commit fixed nested runtimes, but it broke the case when no outside runtime was started.