### PR TITLE
linux: libei: Choose which async runtime you want

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,17 +32,23 @@ jobs:
           - windows-latest
           - macos-latest
         features:
-          - "libei,wayland,xdo,x11rb"
+          - "libei_tokio,wayland,xdo,x11rb"
+          - "libei_smol,wayland,xdo,x11rb"
           - "default"
-          - "libei"
+          - "libei_tokio"
+          - "libei_smol"
           - "wayland"
           - "xdo"
           - "x11rb"
         exclude:
           - platform: windows-latest
-            features: "libei,wayland,xdo,x11rb"
+            features: "libei_tokio,wayland,xdo,x11rb"
           - platform: windows-latest
-            features: "libei"
+            features: "libei_smol,wayland,xdo,x11rb"
+          - platform: windows-latest
+            features: "libei_tokio"
+          - platform: windows-latest
+            features: "libei_smol"
           - platform: windows-latest
             features: "wayland"
           - platform: windows-latest
@@ -50,9 +56,13 @@ jobs:
           - platform: windows-latest
             features: "x11rb"
           - platform: macos-latest
-            features: "libei,wayland,xdo,x11rb"
+            features: "libei_tokio,wayland,xdo,x11rb"
           - platform: macos-latest
-            features: "libei"
+            features: "libei_smol,wayland,xdo,x11rb"
+          - platform: macos-latest
+            features: "libei_tokio"
+          - platform: macos-latest
+            features: "libei_smol"
           - platform: macos-latest
             features: "wayland"
           - platform: macos-latest

--- a/.github/workflows/failing_tests.yml
+++ b/.github/workflows/failing_tests.yml
@@ -32,18 +32,24 @@ jobs:
           - macos-latest
         features: 
           # The tests will fail on Ubuntu for libei and wayland, because the compositor of the Github runner does not support it
-          #- "libei,wayland,xdo,x11rb"
+          #- "libei_tokio,wayland,xdo,x11rb"
+          #- "libei_smol,wayland,xdo,x11rb"
           - "default"
-          #- "libei"
+          #- "libei_smol"
+          #- "libei_tokio"
           #- "wayland"
           - "xdo"
           - "x11rb"
         exclude:
           # The implementation on Windows and macOS does not have any features so we can reduce the number of combinations
           #- platform: windows-latest
-          #  features: "libei,wayland,xdo,x11rb"
+          #  features: "libei_tokio,wayland,xdo,x11rb"
           #- platform: windows-latest
-          #  features: "libei"
+          #  features: "libei_smol,wayland,xdo,x11rb"
+          #- platform: windows-latest
+          #  features: "libei_tokio"
+          #- platform: windows-latest
+          #  features: "libei_smol"
           #- platform: windows-latest
           #  features: "wayland"
           - platform: windows-latest
@@ -51,9 +57,13 @@ jobs:
           - platform: windows-latest
             features: "x11rb"
           #- platform: macos-latest
-          #  features: "libei,wayland,xdo,x11rb"
+          #  features: "libei_tokio,wayland,xdo,x11rb"
           #- platform: macos-latest
-          #  features: "libei"
+          #  features: "libei_smol,wayland,xdo,x11rb"
+          #- platform: macos-latest
+          #  features: "libei_tokio"
+          #- platform: macos-latest
+          #  features: "libei_smol"
           #- platform: macos-latest
           #  features: "wayland"
           - platform: macos-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,17 +31,23 @@ jobs:
           - windows-latest
           - macos-latest
         features:
-         # - "libei,wayland,xdo,x11rb"
+         # - "libei_tokio,wayland,xdo,x11rb"
+         # - "libei_smol,wayland,xdo,x11rb"
           - "default"
-         # - "libei"
+         # - "libei_tokio"
+         # - "libei_smol"
          # - "wayland"
           - "xdo"
           - "x11rb"
         exclude:
          # - platform: windows-latest
-         #   features: "libei,wayland,xdo,x11rb"
+         #   features: "libei_tokio,wayland,xdo,x11rb"
          # - platform: windows-latest
-         #   features: "libei"
+         #   features: "libei_smol,wayland,xdo,x11rb"
+         # - platform: windows-latest
+         #   features: "libei_tokio"
+         # - platform: windows-latest
+         #   features: "libei_smol"
          # - platform: windows-latest
          #   features: "wayland"
           - platform: windows-latest
@@ -49,9 +55,13 @@ jobs:
           - platform: windows-latest
             features: "x11rb"
          # - platform: macos-latest
-         #   features: "libei,wayland,xdo,x11rb"
+         #   features: "libei_tokio,wayland,xdo,x11rb"
          # - platform: macos-latest
-         #   features: "libei"
+         #   features: "libei_smol,wayland,xdo,x11rb"
+         # - platform: macos-latest
+         #   features: "libei_tokio"
+         # - platform: macos-latest
+         #   features: "libei_smol"
          # - platform: macos-latest
          #   features: "wayland"
           - platform: macos-latest
@@ -79,7 +89,7 @@ jobs:
         run: brew install --cask firefox
 
       - name: Run integration tests in release mode
-        if: matrix.features != 'wayland' && matrix.features != 'libei' && matrix.features != 'libei,wayland,xdo,x11rb' # On Linux, the integration tests only work with X11 for now
+        if: matrix.features != 'wayland' && matrix.features != 'libei_tokio' && matrix.features != 'libei_smol' && matrix.features != 'libei_tokio,wayland,xdo,x11rb'&& matrix.features != 'libei_smol,wayland,xdo,x11rb' # On Linux, the integration tests only work with X11 for now
         run: cargo test integration --release --no-default-features --features ${{ matrix.features }} -- --test-threads=1 --nocapture --include-ignored
 
       - name: Take screenshot

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,18 +32,24 @@ jobs:
           - macos-latest
         features: 
           # The tests will fail on Ubuntu for libei and wayland, because the compositor of the Github runner does not support it
-          #- "libei,wayland,xdo,x11rb"
+          #- "libei_tokio,wayland,xdo,x11rb"
+          #- "libei_smol,wayland,xdo,x11rb"
           - "default"
-          #- "libei"
+          #- "libei_tokio"
+          #- "libei_smol"
           #- "wayland"
           - "xdo"
           - "x11rb"
         exclude:
           # The implementation on Windows and macOS does not have any features so we can reduce the number of combinations
           #- platform: windows-latest
-          #  features: "libei,wayland,xdo,x11rb"
+          #  features: "libei_tokio,wayland,xdo,x11rb"
           #- platform: windows-latest
-          #  features: "libei"
+          #  features: "libei_smol,wayland,xdo,x11rb"
+          #- platform: windows-latest
+          #  features: "libei_tokio"
+          #- platform: windows-latest
+          #  features: "libei_smol"
           #- platform: windows-latest
           #  features: "wayland"
           - platform: windows-latest
@@ -51,9 +57,13 @@ jobs:
           - platform: windows-latest
             features: "x11rb"
           #- platform: macos-latest
-          #  features: "libei,wayland,xdo,x11rb"
+          #  features: "libei_tokio,wayland,xdo,x11rb"
           #- platform: macos-latest
-          #  features: "libei"
+          #  features: "libei_smol,wayland,xdo,x11rb"
+          #- platform: macos-latest
+          #  features: "libei_tokio"
+          #- platform: macos-latest
+          #  features: "libei_smol"
           #- platform: macos-latest
           #  features: "wayland"
           - platform: macos-latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,11 @@
 # Unreleased
 ## Changed
+- linux: libei: Replaced `libei` feature with `libei_tokio` and `libei_smol`
 
 ## Added
 - all: So far only functions that were possible on all platforms were implemented in order to keep every thing cross-platform. The new feature `platform_specific` allows you to opt-in to functionality that is only available on one or more platforms. At the beginning the only new platform specific function is smooth scrolling on macOS.
 - macos: added smooth scrolling (only available on macos and hidden behind the `platform_specific` feature)
+- linux: libei: Chose which async runtime you want to use
 
 ## Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,21 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["x11rb"]
-libei = ["dep:reis", "dep:ashpd", "dep:futures", "dep:nom"]
+libei_tokio = [
+    "dep:reis",
+    "dep:ashpd",
+    "ashpd/tokio",
+    "tokio",
+    "dep:futures",
+    "dep:nom",
+]
+libei_smol = [
+    "dep:reis",
+    "dep:ashpd",
+    "ashpd/async-std",
+    "dep:futures",
+    "dep:nom",
+]
 platform_specific = []
 serde = ["dep:serde"]
 wayland = [
@@ -74,10 +88,9 @@ foreign-types-shared = "0.3"
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 libc = "0.2"
 reis = { version = "0.5", optional = true }
-ashpd = { version = "0.11", features = [
-    "async-std",
-], default-features = false, optional = true }
+ashpd = { version = "0.11", default-features = false, optional = true }
 futures = { version = "0.3", optional = true }
+tokio = { version = "1.0", optional = true }
 wayland-protocols-misc = { version = "0.3", features = [
     "client",
 ], optional = true }

--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -1086,5 +1086,10 @@ impl TryFrom<Key> for windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY {
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
-#[cfg(any(feature = "wayland", feature = "x11rb", feature = "libei"))]
+#[cfg(any(
+    feature = "wayland",
+    feature = "x11rb",
+    feature = "libei_tokio",
+    feature = "libei_smol"
+))]
 pub(crate) type ModifierBitflag = u32;


### PR DESCRIPTION
Previously we forced all users to use async-std. Now you can choose whichever you want with the mutually exclusive feature flags `libei_tokio` and `libei_smol`