### PR TITLE
linux: libei: Require at least tokio 1.23 to be secure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ libc = "0.2"
 reis = { version = "0.5", optional = true }
 ashpd = { version = "0.12", default-features = false, optional = true }
 futures = { version = "0.3", optional = true }
-tokio = { version = "1.0", optional = true }
+tokio = { version = "1.23", optional = true }
 wayland-protocols-misc = { version = "0.3", features = [
     "client",
 ], optional = true }


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2023-0001.html