### PR TITLE
win: Fix simulating extended keys

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,12 @@
 ## Added
 
 ## Removed
+- win: `EXT` constant was removed, because it was incorrect and obsolete
 
 ## Fixed
+- linux: Added `NumpadEnter` key
+- win: Added `NumpadEnter` key
+- win: Extended keys can now be correctly simulated with the raw() function.
 
 # 0.6.1
 ## Fixed

--- a/examples/platform_specific.rs
+++ b/examples/platform_specific.rs
@@ -19,8 +19,10 @@ fn main() {
         // windows: Enter divide symbol (slash)
         enigo.key(Key::Divide, Click).unwrap();
 
-        // windows: Press and release the NumLock key. Without the EXT bit set, it would
-        // enter the Pause key
-        enigo.raw(45 | enigo::EXT, enigo::Direction::Click).unwrap();
+        // Windows: Simulate pressing and releasing the Control key.
+        // 0x1D       = Left Control (normal scancode)
+        // 0xE01D     = Right Control (extended scancode; 0xE0 prefix in the high byte)
+        enigo.raw(0x1D, enigo::Direction::Click).unwrap(); // LControl
+        enigo.raw(0x1D | 0xE000, enigo::Direction::Click).unwrap(); // RControl
     }
 }

--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -431,6 +431,8 @@ pub enum Key {
     Numpad7,
     Numpad8,
     Numpad9,
+    #[cfg(any(target_os = "windows", all(unix, not(target_os = "macos"))))]
+    NumpadEnter,
     #[cfg(target_os = "windows")]
     OEM1,
     #[cfg(target_os = "windows")]
@@ -636,6 +638,7 @@ impl From<Key> for xkeysym::Keysym {
             Key::Divide => Keysym::KP_Divide,
             Key::DownArrow => Keysym::Down,
             Key::End => Keysym::End,
+            Key::NumpadEnter => Keysym::KP_Enter,
             Key::Escape => Keysym::Escape,
             Key::Execute => Keysym::Execute,
             Key::F1 => Keysym::F1,
@@ -1011,7 +1014,12 @@ impl TryFrom<Key> for windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY {
             Key::Processkey => VK_PROCESSKEY,
             Key::RButton => VK_RBUTTON,
             Key::RControl => VK_RCONTROL,
-            Key::Return => VK_RETURN,
+            /* Both the main Return key and the
+             * numpad Enter use VK_RETURN. They are
+             * distinguished by their scan codes:
+             * - Return: standard scan code
+             * - NumpadEnter: extended scan code (0xE01C) */
+            Key::Return | Key::NumpadEnter => VK_RETURN,
             Key::RightArrow => VK_RIGHT,
             Key::RMenu => VK_RMENU,
             Key::RShift => VK_RSHIFT,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,6 @@ mod platform;
 pub use platform::Enigo;
 
 #[cfg(target_os = "windows")]
-pub use platform::EXT;
-#[cfg(target_os = "windows")]
 pub use platform::set_dpi_awareness;
 
 mod keycodes;
@@ -277,8 +275,9 @@ pub trait Keyboard {
     /// games). Have a look at the [`Keyboard::key`] function,
     /// if you just want to enter a specific key and don't want to worry about
     /// the layout/keymap. Windows only: If you want to enter the keycode
-    /// (scancode) of an extended key, you need to set extra bits. You can
-    /// for example do: `enigo.raw(45 | EXT, Direction::Click)`
+    /// (scancode) of an extended key, you need to set the high byte for the
+    /// extended key too. You can for example do: `enigo.raw(0xE01D,
+    /// Direction::Click) to simulate RControl`
     ///
     /// # Errors
     /// Have a look at the documentation of [`InputError`] to see under which

--- a/src/win/mod.rs
+++ b/src/win/mod.rs
@@ -1,2 +1,2 @@
 mod win_impl;
-pub use win_impl::{EXT, Enigo, set_dpi_awareness};
+pub use win_impl::{Enigo, set_dpi_awareness};


### PR DESCRIPTION
- linux: Added `NumpadEnter` key
- win: Added `NumpadEnter` key
- win: Extended keys can now be correctly simulated with the raw() function.
- win: Removed the enigo::EXT constand
Fixes https://github.com/enigo-rs/enigo/issues/476