### PR TITLE
Replace println! with debug! to keep the order of the output in sync

### DIFF
--- a/src/linux/keymap2/parse_keymap.rs
+++ b/src/linux/keymap2/parse_keymap.rs
@@ -707,7 +707,7 @@ mod tests {
             aliases: correct_aliases,
         };
 
-        println!("{correct_keycodes_struct}");
+        log::debug!("{correct_keycodes_struct}");
 
         assert_eq!(
             Keycodes::parse(keycodes_str),
@@ -1275,7 +1275,7 @@ xkb_symbols "(unnamed)" {
     r#"Mod4 { <RWIN> }"#.to_string()],
         };
 
-        println!("{correct_symbols}");
+        log::debug!("{correct_symbols}");
 
         assert_eq!(Symbols::parse(symbols_str), Ok(("", correct_symbols)));
     }

--- a/src/linux/libei.rs
+++ b/src/linux/libei.rs
@@ -196,7 +196,7 @@ impl Con {
             // TODO: Should all devices start emulating?
             // && device_data.interface::<ei::Keyboard>().is_some()
         }) {
-            println!("Start emulating");
+            debug!("Start emulating");
             if !device.is_alive() {
                 return Err(NewConError::EstablishCon("ei::Device is no longer alive"));
             }
@@ -761,7 +761,7 @@ impl Drop for Con {
             device_data.device_type == Some(reis::ei::device::DeviceType::Virtual)
                 && device_data.state == DeviceState::Emulating
         }) {
-            println!("DROPPED");
+            debug!("DROPPED");
             device.stop_emulating(self.last_serial);
             self.last_serial = self.last_serial.wrapping_add(1);
         }

--- a/src/tests/mouse.rs
+++ b/src/tests/mouse.rs
@@ -92,7 +92,7 @@ fn unit_move_mouse_to_boundaries() {
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
 
     let display_size = enigo.main_display().unwrap();
-    println!("Display size {} x {}", display_size.0, display_size.1);
+    log::debug!("Display size {} x {}", display_size.0, display_size.1);
 
     // Move the mouse outside of the boundaries of the screen
     let screen_boundaries = vec![
@@ -130,7 +130,7 @@ fn unit_move_mouse_rel_boundaries() {
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
 
     let display_size = enigo.main_display().unwrap();
-    println!("Display size {} x {}", display_size.0, display_size.1);
+    log::debug!("Display size {} x {}", display_size.0, display_size.1);
 
     // Move the mouse outside of the boundaries of the screen
     let screen_boundaries = vec![
@@ -170,7 +170,7 @@ fn unit_move_mouse_rel_boundaries() {
 fn unit_display_size() {
     let enigo = Enigo::new(&Settings::default()).unwrap();
     let display_size = enigo.main_display().unwrap();
-    println!("Main display size: {}x{}", display_size.0, display_size.1);
+    log::debug!("Main display size: {}x{}", display_size.0, display_size.1);
     if is_ci() {
         assert_eq!((display_size.0, display_size.1), (1024, 768));
     } else {

--- a/tests/common/browser_events.rs
+++ b/tests/common/browser_events.rs
@@ -67,23 +67,23 @@ impl TryFrom<Message> for BrowserEvent {
     fn try_from(message: Message) -> Result<Self, Self::Error> {
         match message {
             Message::Close(_) => {
-                println!("Message::Close received");
+                log::debug!("Message::Close received");
                 Err(BrowserEventError::WebsocketClosed)
             }
             Message::Text(msg) => {
-                println!("Browser received input");
-                println!("msg: {msg:?}");
+                log::debug!("Browser received input");
+                log::debug!("msg: {msg:?}");
 
                 // Attempt to deserialize the text message into a BrowserEvent
                 if let Ok(event) = serde_json::from_str::<BrowserEvent>(&msg) {
                     Ok(event)
                 } else {
-                    println!("Parse error! Message: {msg}");
+                    log::debug!("Parse error! Message: {msg}");
                     Err(BrowserEventError::ParseError)
                 }
             }
             Message::Binary(_) | Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {
-                println!("Other Message received");
+                log::debug!("Other Message received");
                 Err(BrowserEventError::UnknownMessageType)
             }
         }
@@ -194,8 +194,8 @@ fn deserialize_browser_events() {
     for (raw, expected) in cases {
         // serialize back to JSON for comparison
         let expected_json = serde_json::to_string(&expected).unwrap();
-        println!("expected = {}", expected_json);
-        println!("raw      = {}\n", raw);
+        log::debug!("expected = {}", expected_json);
+        log::debug!("raw      = {}\n", raw);
 
         // parse the JSON
         let msg = Message::Text(raw.into());

--- a/tests/common/enigo_test.rs
+++ b/tests/common/enigo_test.rs
@@ -30,23 +30,23 @@ impl EnigoTest {
 
     fn websocket() -> tungstenite::WebSocket<TcpStream> {
         let listener = TcpListener::bind("127.0.0.1:26541").expect("failed to bind to port");
-        println!("TcpListener was created");
+        log::debug!("TcpListener was created");
         let (stream, addr) = listener.accept().expect("Unable to accept the connection");
-        println!("New connection was made from {addr:?}");
+        log::debug!("New connection was made from {addr:?}");
         let websocket = accept(stream).expect("Unable to accept connections on the websocket");
-        println!("WebSocket was successfully created");
+        log::debug!("WebSocket was successfully created");
         websocket
     }
 
     fn read_message(&mut self) -> BrowserEvent {
         use crate::common::browser_events::BrowserEventError;
 
-        println!("Waiting for message on Websocket");
+        log::debug!("Waiting for message on Websocket");
         let message = self
             .websocket
             .read()
             .expect("failed to read from websocket");
-        println!("Processing message");
+        log::debug!("Processing message");
 
         BrowserEvent::try_from(message).unwrap_or_else(|e| match e {
             BrowserEventError::WebsocketClosed => {
@@ -60,7 +60,7 @@ impl EnigoTest {
     fn start_timeout_thread() {
         std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_secs(TIMEOUT * 60));
-            println!("Test suite exceeded the maximum allowed time of {TIMEOUT} minutes.");
+            log::debug!("Test suite exceeded the maximum allowed time of {TIMEOUT} minutes.");
             std::process::exit(1); // Exit with error code
         });
     }

--- a/tests/integration_browser.rs
+++ b/tests/integration_browser.rs
@@ -26,7 +26,7 @@ fn integration_browser_events() {
     // https://github.com/jordansissel/xdotool/issues/487
     #[cfg(not(feature = "xdo"))]
     {
-        println!("Test if the left and right versions of keys can get differentiated");
+        log::debug!("Test if the left and right versions of keys can get differentiated");
         enigo.key(Key::Control, Press).unwrap();
         enigo.key(Key::Control, Release).unwrap();
         enigo.key(Key::LControl, Press).unwrap();
@@ -38,7 +38,7 @@ fn integration_browser_events() {
         enigo.key(Key::RShift, Click).unwrap();
     }
 
-    println!("Test mouse");
+    log::debug!("Test mouse");
     // enigo.button(Button::Left, Click).unwrap();
     enigo.move_mouse(100, 100, Abs).unwrap();
     enigo.move_mouse(200, 200, Abs).unwrap();


### PR DESCRIPTION
If println! and debug! are both used, it can happen that the order of the output is incorrect.