### PR TITLE
tests: fix fast_text on macOS where input arrives as a single key-press

### DIFF
--- a/tests/common/enigo_test.rs
+++ b/tests/common/enigo_test.rs
@@ -71,11 +71,21 @@ impl Keyboard for EnigoTest {
         let mut expected_text = text.to_string();
         self.enigo.text(text).expect("failed to simulate text()");
 
-        loop {
-            if expected_text.is_empty() {
-                break;
-            }
-            let observed_text = self.read_message().text;
+        if cfg!(target_os = "macos") {}
+
+        while !expected_text.is_empty() {
+            let browser_event = self.read_message();
+            let BrowserEvent {
+                text: observed_text,
+                event: Event::Key { key, .. },
+            } = browser_event
+            else {
+                panic!("wrong event received: {browser_event:?}")
+            };
+
+            #[cfg(target_os = "macos")]
+            let observed_text = key;
+
             match expected_text.strip_prefix(&observed_text) {
                 Some(remainder) => expected_text = remainder.to_string(),
                 None => panic!("failed to simulate text()"),


### PR DESCRIPTION
On Linux/Windows Enigo simulates text as individual key press+release events; the browser updates its text on key release and the test reads that text (before the browser clears it). On macOS Enigo emits the whole text via a single key-press event (there is no per-character key release), so the test was reading on release and seeing nothing.

Adjust the test to accept the browser's Key event on macOS and use the key payload as the observed text. Keep the existing behavior on other platforms. This fixes the macOS-only test failure in `fast_text`.