### PR TITLE
tests: Align macOS Firefox kiosk mode with Windows/Linux

### DIFF
--- a/tests/firefox-profile/user.js
+++ b/tests/firefox-profile/user.js
@@ -8,3 +8,18 @@ user_pref("browser.startup.firstrunSkipsHomepage", true);
 user_pref("datareporting.policy.dataSubmissionPolicyAcceptedVersion", 2);
 user_pref("datareporting.policy.dataSubmissionPolicyNotifiedTime", "1759697962369");
 user_pref("distribution.canonical-002.bookmarksProcessed", true);
+
+// Disable tabs if not needed
+user_pref("browser.tabs.drawInTitlebar", false);
+user_pref("browser.tabs.closeButtons", 0);
+
+// Hide menu bar
+user_pref("browser.fullscreen.autohide", true);
+
+// Disable title bar
+user_pref("browser.tabs.allowTabDetach", false);
+
+// Force fullscreen when kiosk mode starts
+user_pref("full-screen-api.ignore-warnings", true);
+user_pref("full-screen-api.transition-duration.enter", "0 0");
+user_pref("full-screen-api.transition-duration.leave", "0 0");


### PR DESCRIPTION
Added user.js preferences to hide menu, tab, and title bars, and force fullscreen transitions on macOS. This ensures kiosk mode coordinates match exactly across Windows, Linux, and macOS. The integration test failed on macOS, because the bars at the top of the screen reduced the size of the test page and the coordinates were wrong