### PR TITLE
macOS: use more types from objc2 crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ windows = { version = "0.62", features = [
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"
-core-graphics = { version = "0.25", features = ["highsierra"] }
+objc2-core-graphics = "0.3"
 objc2 = { version = "0.6", features = ["relax-void-encoding"] }
 objc2-app-kit = { version = "0.3", default-features = false, features = [
     "std",

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -4,13 +4,25 @@ use std::{
     time::{Duration, Instant},
 };
 
-use core_foundation::{
-    array::CFIndex,
-    base::{CFRelease, OSStatus, TCFType, UInt8, UInt16, UInt32},
-    data::{CFDataGetBytePtr, CFDataRef},
-    dictionary::{CFDictionary, CFDictionaryRef},
-    string::{CFString, CFStringRef, UniChar},
+use objc2_foundation::{
+    CFIndex,
+    NSData,
+    NSDictionary,
+    NSString,
+    OSStatus,
+    // You may still need TCFType/CFRelease depending on your APIs:
+    base::{CFRelease, TCFType, UInt8, UInt16, UInt32},
 };
+
+// CoreGraphics equivalents from objc2-core-graphics
+use objc2_core_graphics::{
+    CGEvent, CGEventFlags, CGEventRef, CGEventTapLocation, CGEventType, CGMouseButton,
+    CGScrollEventUnit,
+    display::CGDisplay,
+    event_source::{CGEventSource, CGEventSourceStateID},
+    geometry::CGPoint,
+};
+
 use core_graphics::{
     display::{CGDisplay, CGPoint},
     event::{
@@ -24,6 +36,13 @@ use log::{debug, error, info};
 use objc2::msg_send;
 use objc2_app_kit::{NSEvent, NSEventModifierFlags, NSEventType};
 use objc2_foundation::NSPoint;
+use objc2_foundation::{
+    CFIndex,
+    base::{CFRelease, OSStatus, TCFType, UInt8, UInt16, UInt32},
+    data::{CFDataGetBytePtr, CFDataRef},
+    dictionary::{CFDictionary, CFDictionaryRef},
+    string::{CFString, CFStringRef, UniChar},
+};
 
 use crate::{
     Axis, Button, Coordinate, Direction, InputError, InputResult, Key, Keyboard, Mouse,


### PR DESCRIPTION
The `CGMouseButton` type of the core_graphics crate is [too limiting](https://github.com/servo/core-foundation-rs/issues/745). It was recommended to me to switch to the `objc2` provided types/functions instead. We already use `objc2`, so it makes sense to move as much of the code to it. The community support seems to be very well for `objc2`.