### PR TITLE
ci: cancel workflows if a new commit was pushed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/failing_tests.yml
+++ b/.github/workflows/failing_tests.yml
@@ -9,6 +9,10 @@ on:
   #   types:
   #     - completed
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
It is wasteful to continue running Workflows if the code was changed already. We only want to do that on main to make sure each commit builds