### PR TITLE
ci: add test to ensure mouse events don't need a sleep afterwards to work

### DIFF
--- a/tests/integration_browser.rs
+++ b/tests/integration_browser.rs
@@ -70,6 +70,13 @@ fn integration_browser_events() {
     enigo.move_mouse(20, -20, Rel).unwrap();
     enigo.move_mouse(-20, -20, Rel).unwrap();
 
+    // Ensure mouse events don't need a sleep afterwards to work
+    enigo.move_mouse(137, 59, Abs).unwrap();
+    enigo.key(Key::Return, Click).unwrap();
+    std::thread::sleep(Duration::from_secs(1));
+    let (x, y) = enigo.location().unwrap();
+    assert_eq!((137, 59), (x, y));
+
     // Stalls on Windows, macOS and Linux with x11rb
     // enigo.scroll(1, Vertical).unwrap();
     // enigo.scroll(1, Horizontal).unwrap();


### PR DESCRIPTION
We currently need to sleep after simulating a mouse move (https://github.com/enigo-rs/enigo/issues/400). I've created a PR to fix that (https://github.com/enigo-rs/enigo/pull/496). This PR adds a test to the CI that fails as long as the sleep statements are needed. The test will help us make sure the PR to fix the issue works and detects regressions in the future.