### PR TITLE
macos: fix crash by executing TIS keyboard layout retrieval on the main thread

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 - macos: `move_mouse` no longer needs a sleep.
 - macos: always get the current main display and not the main display when the `enigo` struct was created
 - macos: allow dragging all mouse buttons
+- macos: fix crash by executing TIS keyboard layout retrieval on the main thread
 
 # 0.6.1
 ## Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ windows = { version = "0.62", features = [
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"
 core-graphics = { version = "0.25", features = ["highsierra"] }
-objc2-core-graphics = { version = "0.3.2", features = [
+objc2-core-graphics = { version = "0.3", features = [
     "CGEventTypes",
     "CGRemoteOperation",
 ] }
@@ -83,13 +83,14 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
     "NSGraphicsContext",
     "objc2-core-graphics",
 ] }
-objc2-core-foundation = { version = "0.3.2", features = ["CFCGTypes"] }
+objc2-core-foundation = { version = "0.3", features = ["CFCGTypes"] }
 objc2-foundation = { version = "0.3", default-features = false, features = [
     "std",
     "objc2-core-foundation",
     "NSGeometry",
 ] }
 foreign-types-shared = "0.3"
+dispatch2 = "0.3"
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 libc = "0.2"


### PR DESCRIPTION
All TIS functions must be called from the main thread. When using Tauri and enigo together, this was often not the case, so the application crashed. To fix this issue, we use the `dispatch2::run_on_main` function to execute the TIS function on main. This only works if the there is for example a `CFRunLoop`. Otherwise it will hang. When the enigo struct is created, we try to detect if the requirement is fulfilled. If it is, we use the `run_on_main` function. If it is not, we don't use it

Fixes https://github.com/enigo-rs/enigo/issues/436
Fixes https://github.com/enigo-rs/enigo/issues/153
Fixes https://github.com/tauri-apps/tauri/issues/6421