### PR TITLE
all: MSRV is 1.87

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.85.0"
+          - "1.87.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/failing_tests.yml
+++ b/.github/workflows/failing_tests.yml
@@ -29,7 +29,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.85.0"
+          - "1.87.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,7 +29,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.85.0"
+          - "1.87.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - "1.85.0"
+          - "1.87.0"
         platform:
           - ubuntu-latest
           - windows-latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 ## Changed
 - linux: Changed order of the protocols to from libei > wayland > x11 to now wayland > x11 > libei
 - linux: Split the features `libei_smol`, `libei_tokio` into the feature `libei` to enable the libei protocol and the mutually exclusive features `smol` and `tokio` to select the async runtime
+- all: MSRV is 1.87
 
 ## Added
 - linux: added new protocol to simulate input. It uses the xdg_desktop portal and should work in flatpaks. Try it out with the `xdg_desktop` feature

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Dustin Bensing <dustin.bensing@googlemail.com>",
 ]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.87"
 description = "Cross-platform (Linux, Windows, macOS & BSD) library to simulate keyboard and mouse events"
 documentation = "https://docs.rs/enigo/"
 homepage = "https://github.com/enigo-rs/enigo"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Docs](https://docs.rs/enigo/badge.svg)](https://docs.rs/enigo)
 [![Dependency status](https://deps.rs/repo/github/enigo-rs/enigo/status.svg)](https://deps.rs/repo/github/enigo-rs/enigo)
 
-![Rust version](https://img.shields.io/badge/rust--version-1.85+-brightgreen.svg)
+![Rust version](https://img.shields.io/badge/rust--version-1.87+-brightgreen.svg)
 [![Crates.io](https://img.shields.io/crates/v/enigo.svg)](https://crates.io/crates/enigo)
 
 # enigo


### PR DESCRIPTION
The zune-jpeg dependency of the image crate requires 1.87 to build. The image crate is used in the xdg_desktop feature