### PR TITLE
fix(x11): resolve keysyms at all keymap levels with proper modifier wrapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ wayland-client = { version = "0.31", optional = true }
 x11rb = { version = "0.13", features = [
     "randr",
     "xinput",
+    "xkb",
     "xtest",
 ], optional = true }
 xkbcommon = "0.9"

--- a/src/linux/keymap.rs
+++ b/src/linux/keymap.rs
@@ -72,8 +72,16 @@ where
         let keycode_min: usize = self.keymap_mapping.keycode_min.try_into().unwrap();
         let keycode_max: usize = self.keymap_mapping.keycode_max.try_into().unwrap();
 
-        for j in 0..self.keymap_mapping.keysyms_per_keycode {
-            for i in keycode_min..=keycode_max {
+        // Iterate keycodes in the outer loop, levels in the inner loop.
+        // This ensures we find keysyms at the lowest keycode first (standard
+        // keyboard range), even at a higher level (e.g. Shift), rather than
+        // finding them at XWayland's extended high keycodes at level 0.
+        // On XWayland, uppercase keysyms like 'H' exist both at high keycodes
+        // (e.g. 219) at level 0 and at the standard 'h' keycode (43) at level 1.
+        // The standard keycode + Shift translates correctly through XWayland,
+        // while the high keycodes do not.
+        for i in keycode_min..=keycode_max {
+            for j in 0..self.keymap_mapping.keysyms_per_keycode {
                 let i: u32 = i.try_into().unwrap();
                 let min_keycode: u32 = keycode_min.try_into().unwrap();
                 let keycode = KeyCode::from(i);

--- a/src/linux/keymap.rs
+++ b/src/linux/keymap.rs
@@ -68,13 +68,11 @@ where
         }
     }
 
-    fn keysym_to_keycode(&self, keysym: Keysym) -> Option<Keycode> {
+    fn keysym_to_keycode(&self, keysym: Keysym) -> Option<(Keycode, u8)> {
         let keycode_min: usize = self.keymap_mapping.keycode_min.try_into().unwrap();
         let keycode_max: usize = self.keymap_mapping.keycode_max.try_into().unwrap();
 
-        // TODO: Change this range to 0..self.keysyms_per_keycode once we find out how
-        // to detect the level and switch it
-        for j in 0..1 {
+        for j in 0..self.keymap_mapping.keysyms_per_keycode {
             for i in keycode_min..=keycode_max {
                 let i: u32 = i.try_into().unwrap();
                 let min_keycode: u32 = keycode_min.try_into().unwrap();
@@ -91,7 +89,7 @@ where
                         let i: usize = i.try_into().unwrap();
                         let i: Keycode = i.try_into().unwrap();
                         trace!("found keysym in row {i}, col {j}");
-                        return Some(i);
+                        return Some((i, j));
                     }
                 }
             }
@@ -101,11 +99,15 @@ where
 
     // Try to enter the key
     #[allow(clippy::unnecessary_wraps)]
-    pub fn key_to_keycode<C: Bind<Keycode>>(&mut self, c: &C, key: Key) -> InputResult<Keycode> {
+    pub fn key_to_keycode<C: Bind<Keycode>>(
+        &mut self,
+        c: &C,
+        key: Key,
+    ) -> InputResult<(Keycode, u8)> {
         let sym = Keysym::from(key);
 
-        if let Some(keycode) = self.keysym_to_keycode(sym) {
-            return Ok(keycode);
+        if let Some((keycode, level)) = self.keysym_to_keycode(sym) {
+            return Ok((keycode, level));
         }
 
         let keycode = {
@@ -121,7 +123,13 @@ where
             }
         };
 
-        Ok(keycode)
+        // bind_key maps to both levels, so level 0 is fine
+        Ok((keycode, 0))
+    }
+
+    /// Check if a keycode is currently held
+    pub fn is_keycode_held(&self, keycode: &Keycode) -> bool {
+        self.keymap_state.held_keycodes.contains(keycode)
     }
 
     /// Add the Keysym to the keymap

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -229,13 +229,28 @@ impl Bind<Keycode> for CompositorConnection {
     }
 }
 
+impl Con {
+    /// Return the modifier keycode needed for a given keysym level.
+    /// Level 0 needs no modifier; level 1 needs Shift (modifier index 0 in X11).
+    fn modifier_keycode_for_level(&self, level: u8) -> Option<Keycode> {
+        match level {
+            0 => None,
+            1 => self.modifiers[0].first().copied(), // Shift = modifier index 0 in X11
+            _ => {
+                warn!("modifier for keysym level {level} not yet supported");
+                None
+            }
+        }
+    }
+}
+
 impl Keyboard for Con {
     fn fast_text(&mut self, _text: &str) -> InputResult<Option<()>> {
         Ok(None)
     }
 
     fn key(&mut self, key: Key, direction: Direction) -> InputResult<()> {
-        let keycode = self.keymap.key_to_keycode(&self.connection, key)?;
+        let (keycode, level) = self.keymap.key_to_keycode(&self.connection, key)?;
 
         if log::log_enabled!(log::Level::Debug) {
             for (mod_idx, mod_keycodes) in self.modifiers.iter().enumerate() {
@@ -245,7 +260,38 @@ impl Keyboard for Con {
             }
         }
 
-        self.raw(keycode.into(), direction)
+        let modifier_kc = self.modifier_keycode_for_level(level);
+
+        if let Some(mod_kc) = modifier_kc {
+            let shift_already_held = self.keymap.is_keycode_held(&mod_kc);
+
+            match direction {
+                Direction::Click => {
+                    if !shift_already_held {
+                        self.raw(mod_kc.into(), Direction::Press)?;
+                    }
+                    self.raw(keycode.into(), Direction::Click)?;
+                    if !shift_already_held {
+                        self.raw(mod_kc.into(), Direction::Release)?;
+                    }
+                }
+                Direction::Press => {
+                    if !shift_already_held {
+                        self.raw(mod_kc.into(), Direction::Press)?;
+                    }
+                    self.raw(keycode.into(), Direction::Press)?;
+                }
+                Direction::Release => {
+                    self.raw(keycode.into(), Direction::Release)?;
+                    if !shift_already_held {
+                        self.raw(mod_kc.into(), Direction::Release)?;
+                    }
+                }
+            }
+            Ok(())
+        } else {
+            self.raw(keycode.into(), direction)
+        }
     }
 
     fn raw(&mut self, keycode: u16, direction: Direction) -> InputResult<()> {

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -235,11 +235,11 @@ impl Con {
     /// X11 keymap columns map to groups and levels:
     /// - Column 0: Group 1, no modifier
     /// - Column 1: Group 1, Shift
-    /// - Column 2: Group 1, Level3 (AltGr/Mode_switch) or Group 2
+    /// - Column 2: Group 1, Level3 (`AltGr/Mode_switch`) or Group 2
     /// - Column 3: Group 1, Level3 + Shift or Group 2 + Shift
     /// - Column 4+: higher levels, typically ISO_Level3_Shift-based
     ///
-    /// On most Linux systems, AltGr is at Mod5 (modifier index 7).
+    /// On most Linux systems, `AltGr` is at Mod5 (modifier index 7).
     fn modifier_keycodes_for_level(&self, level: u8) -> Vec<Keycode> {
         match level {
             0 => vec![],

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -230,15 +230,51 @@ impl Bind<Keycode> for CompositorConnection {
 }
 
 impl Con {
-    /// Return the modifier keycode needed for a given keysym level.
-    /// Level 0 needs no modifier; level 1 needs Shift (modifier index 0 in X11).
-    fn modifier_keycode_for_level(&self, level: u8) -> Option<Keycode> {
+    /// Return the modifier keycodes needed for a given keysym level.
+    ///
+    /// X11 keymap columns map to groups and levels:
+    /// - Column 0: Group 1, no modifier
+    /// - Column 1: Group 1, Shift
+    /// - Column 2: Group 1, Level3 (AltGr/Mode_switch) or Group 2
+    /// - Column 3: Group 1, Level3 + Shift or Group 2 + Shift
+    /// - Column 4+: higher levels, typically ISO_Level3_Shift-based
+    ///
+    /// On most Linux systems, AltGr is at Mod5 (modifier index 7).
+    fn modifier_keycodes_for_level(&self, level: u8) -> Vec<Keycode> {
         match level {
-            0 => None,
-            1 => self.modifiers[0].first().copied(), // Shift = modifier index 0 in X11
+            0 => vec![],
+            1 => self.modifiers[0].first().copied().into_iter().collect(), // Shift
+            2 | 4 => {
+                // AltGr / ISO_Level3_Shift / Mode_switch - typically Mod5 (index 7)
+                // Fall back to Mod3 (index 5) if Mod5 is empty
+                if let Some(&kc) = self.modifiers[7].first() {
+                    vec![kc]
+                } else if let Some(&kc) = self.modifiers[5].first() {
+                    vec![kc]
+                } else {
+                    warn!("no AltGr modifier found for keysym level {level}");
+                    vec![]
+                }
+            }
+            3 | 5 => {
+                // AltGr + Shift
+                let mut mods = vec![];
+                if let Some(&kc) = self.modifiers[7].first() {
+                    mods.push(kc);
+                } else if let Some(&kc) = self.modifiers[5].first() {
+                    mods.push(kc);
+                }
+                if let Some(&kc) = self.modifiers[0].first() {
+                    mods.push(kc);
+                }
+                if mods.is_empty() {
+                    warn!("no modifiers found for keysym level {level}");
+                }
+                mods
+            }
             _ => {
                 warn!("modifier for keysym level {level} not yet supported");
-                None
+                vec![]
             }
         }
     }
@@ -260,37 +296,42 @@ impl Keyboard for Con {
             }
         }
 
-        let modifier_kc = self.modifier_keycode_for_level(level);
+        let mod_keycodes = self.modifier_keycodes_for_level(level);
 
-        if let Some(mod_kc) = modifier_kc {
-            let shift_already_held = self.keymap.is_keycode_held(&mod_kc);
+        if mod_keycodes.is_empty() {
+            self.raw(keycode.into(), direction)
+        } else {
+            // Track which modifiers we actually need to press (skip already-held ones)
+            let mods_to_press: Vec<Keycode> = mod_keycodes
+                .iter()
+                .copied()
+                .filter(|kc| !self.keymap.is_keycode_held(kc))
+                .collect();
 
             match direction {
                 Direction::Click => {
-                    if !shift_already_held {
+                    for &mod_kc in &mods_to_press {
                         self.raw(mod_kc.into(), Direction::Press)?;
                     }
                     self.raw(keycode.into(), Direction::Click)?;
-                    if !shift_already_held {
+                    for &mod_kc in mods_to_press.iter().rev() {
                         self.raw(mod_kc.into(), Direction::Release)?;
                     }
                 }
                 Direction::Press => {
-                    if !shift_already_held {
+                    for &mod_kc in &mods_to_press {
                         self.raw(mod_kc.into(), Direction::Press)?;
                     }
                     self.raw(keycode.into(), Direction::Press)?;
                 }
                 Direction::Release => {
                     self.raw(keycode.into(), Direction::Release)?;
-                    if !shift_already_held {
+                    for &mod_kc in mods_to_press.iter().rev() {
                         self.raw(mod_kc.into(), Direction::Release)?;
                     }
                 }
             }
             Ok(())
-        } else {
-            self.raw(keycode.into(), direction)
         }
     }
 

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -7,6 +7,7 @@ use x11rb::{
     protocol::{
         randr::ConnectionExt as _,
         xinput::DeviceUse,
+        xkb::{self, ConnectionExt as _},
         xproto::{ConnectionExt as _, GetKeyboardMappingReply, GetModifierMappingReply, Screen},
         xtest::ConnectionExt as _,
     },
@@ -28,6 +29,12 @@ pub struct Con {
     screen: Screen,
     keymap: KeyMap<Keycode>,
     modifiers: [Vec<Keycode>; 8],
+    min_keycode: Keycode,
+    /// XKB key types, indexed by key type index
+    key_types: Vec<xkb::KeyType>,
+    /// XKB key type indices per group for every keycode, indexed by
+    /// `keycode - min_keycode`
+    key_type_indices: Vec<[u8; 4]>,
 }
 
 impl From<ConnectionError> for NewConError {
@@ -85,12 +92,67 @@ impl Con {
         // Get the keycodes of the modifiers
         let modifiers = Self::find_modifier_keycodes(&connection)?;
 
+        // Get the XKB key types so the modifiers needed to reach a keysym level
+        // can be derived from the keymap instead of being hardcoded
+        let (key_types, key_type_indices) = Self::get_key_types(&connection)?;
+
         Ok(Con {
             connection,
             screen,
             keymap,
             modifiers,
+            min_keycode,
+            key_types,
+            key_type_indices,
         })
+    }
+
+    /// Get the XKB key types and the key type assigned to every keycode.
+    ///
+    /// A key type describes, for each keysym level, the modifier combination
+    /// that selects it. Together with the key type assigned to each key, this
+    /// is the keymap's own description of which modifiers switch to which
+    /// level, so it can be used instead of assuming fixed modifiers.
+    fn get_key_types(
+        connection: &CompositorConnection,
+    ) -> Result<(Vec<xkb::KeyType>, Vec<[u8; 4]>), NewConError> {
+        // The XKB extension has to be initialized before any of its requests
+        // can be used
+        connection.xkb_use_extension(1, 0)?.reply()?;
+
+        let reply = connection
+            .xkb_get_map(
+                xkb::ID::USE_CORE_KBD.into(),
+                xkb::MapPart::KEY_TYPES | xkb::MapPart::KEY_SYMS, // return these fully
+                xkb::MapPart::from(0u16),                         // nothing partially
+                0,                                                // first_type
+                0,                                                // n_types
+                0,                                                // first_key_sym
+                0,                                                // n_key_syms
+                0,                                                // first_key_action
+                0,                                                // n_key_actions
+                0,                                                // first_key_behavior
+                0,                                                // n_key_behaviors
+                xkb::VMod::from(0u16),
+                0, // first_key_explicit
+                0, // n_key_explicit
+                0, // first_mod_map_key
+                0, // n_mod_map_keys
+                0, // first_v_mod_map_key
+                0, // n_v_mod_map_keys
+            )?
+            .reply()?;
+
+        let key_types = reply.map.types_rtrn.unwrap_or_default();
+        let key_type_indices = reply
+            .map
+            .syms_rtrn
+            .unwrap_or_default()
+            .iter()
+            .map(|sym_map| sym_map.kt_index)
+            .collect();
+
+        Ok((key_types, key_type_indices))
     }
 
     /// Find keycodes that have not yet been mapped any keysyms
@@ -230,53 +292,60 @@ impl Bind<Keycode> for CompositorConnection {
 }
 
 impl Con {
-    /// Return the modifier keycodes needed for a given keysym level.
+    /// Return the modifier keycodes needed to reach `level` for `keycode`.
     ///
-    /// X11 keymap columns map to groups and levels:
-    /// - Column 0: Group 1, no modifier
-    /// - Column 1: Group 1, Shift
-    /// - Column 2: Group 1, Level3 (`AltGr/Mode_switch`) or Group 2
-    /// - Column 3: Group 1, Level3 + Shift or Group 2 + Shift
-    /// - Column 4+: higher levels, typically ISO_Level3_Shift-based
+    /// The level-to-modifier relationship is read from the XKB key types
+    /// instead of being hardcoded, because it is not guaranteed to be the same
+    /// for every keymap (e.g. `AltGr` is not always mapped to the same
+    /// modifier).
     ///
-    /// On most Linux systems, `AltGr` is at Mod5 (modifier index 7).
-    fn modifier_keycodes_for_level(&self, level: u8) -> Vec<Keycode> {
-        match level {
-            0 => vec![],
-            1 => self.modifiers[0].first().copied().into_iter().collect(), // Shift
-            2 | 4 => {
-                // AltGr / ISO_Level3_Shift / Mode_switch - typically Mod5 (index 7)
-                // Fall back to Mod3 (index 5) if Mod5 is empty
-                if let Some(&kc) = self.modifiers[7].first() {
-                    vec![kc]
-                } else if let Some(&kc) = self.modifiers[5].first() {
-                    vec![kc]
-                } else {
-                    warn!("no AltGr modifier found for keysym level {level}");
-                    vec![]
-                }
+    /// Each key type lists, for every level, the real modifier mask that
+    /// selects it. We resolve the key type assigned to the key's base group,
+    /// look up the mask for the requested level and translate that mask into
+    /// the keycodes of the corresponding modifiers.
+    fn modifier_keycodes_for_level(&self, keycode: Keycode, level: u8) -> Vec<Keycode> {
+        // The base level never needs a modifier
+        if level == 0 {
+            return vec![];
+        }
+
+        let Some(mods_mask) = self.level_modifier_mask(keycode, level) else {
+            warn!("no key type modifier mapping found for keycode {keycode} at level {level}");
+            return vec![];
+        };
+
+        // Translate the real modifier mask into the keycodes of those
+        // modifiers. Bit i of the mask corresponds to self.modifiers[i]
+        // (0: Shift, 1: Lock, 2: Control, 3-7: Mod1-Mod5).
+        let mut mod_keycodes = vec![];
+        for (i, keycodes) in self.modifiers.iter().enumerate() {
+            if mods_mask & (1u16 << i) == 0 {
+                continue;
             }
-            3 | 5 => {
-                // AltGr + Shift
-                let mut mods = vec![];
-                if let Some(&kc) = self.modifiers[7].first() {
-                    mods.push(kc);
-                } else if let Some(&kc) = self.modifiers[5].first() {
-                    mods.push(kc);
-                }
-                if let Some(&kc) = self.modifiers[0].first() {
-                    mods.push(kc);
-                }
-                if mods.is_empty() {
-                    warn!("no modifiers found for keysym level {level}");
-                }
-                mods
-            }
-            _ => {
-                warn!("modifier for keysym level {level} not yet supported");
-                vec![]
+            if let Some(&kc) = keycodes.first() {
+                mod_keycodes.push(kc);
+            } else {
+                warn!("modifier no {i} selects level {level} but has no keycode mapped");
             }
         }
+        mod_keycodes
+    }
+
+    /// Look up the real modifier mask that selects `level` for `keycode` in the
+    /// XKB key types.
+    fn level_modifier_mask(&self, keycode: Keycode, level: u8) -> Option<u16> {
+        let index = usize::from(keycode.checked_sub(self.min_keycode)?);
+        let kt_index = self.key_type_indices.get(index)?;
+        // Use the base group (group 1). Reaching a level in a higher group
+        // would additionally require a group-switch modifier, which the levels
+        // resolved here do not use.
+        let key_type = self.key_types.get(usize::from(kt_index[0]))?;
+
+        key_type
+            .map
+            .iter()
+            .find(|entry| entry.active && entry.level == level)
+            .map(|entry| u16::from(entry.mods_mask))
     }
 }
 
@@ -296,7 +365,7 @@ impl Keyboard for Con {
             }
         }
 
-        let mod_keycodes = self.modifier_keycodes_for_level(level);
+        let mod_keycodes = self.modifier_keycodes_for_level(keycode, level);
 
         if mod_keycodes.is_empty() {
             self.raw(keycode.into(), direction)


### PR DESCRIPTION
## Summary

The x11rb backend's `keysym_to_keycode` had three related issues:

1. **Only level 0 was searched.** Uppercase letters and shifted symbols (like `A`, `!`, `@`) were never found at their native keycode. Every shifted character fell through to the `XChangeKeyboardMapping` dynamic-remapping path, introducing a race condition that dropped characters during fast `text()` input.

2. **Loop order favored XWayland's extended high keycodes.** On XWayland, uppercase keysyms like `H` exist at both an extended high keycode (e.g. 219) at level 0 and the standard `h` keycode (43) at level 1. The old loop order (levels outer, keycodes inner) found the high-keycode match first. XTest events at these high keycodes don't translate correctly through XWayland to Wayland - the evdev keycode has no real key mapping - causing uppercase letters and shifted symbols to produce no output.

3. **Only Shift (level 1) was handled.** Characters at levels 2-5 (AltGr, AltGr+Shift) were not supported. On international keyboards like Portuguese, common characters such as `@` (AltGr+2) live at level 2 and were never resolved.

### Changes

- **Search all `keysyms_per_keycode` levels** instead of just level 0, resolving the TODO that was already in the code
- **Iterate keycodes in the outer loop, levels in the inner loop**, so standard keycodes are found before XWayland's extended high keycodes
- **Return the level** alongside the keycode from `keysym_to_keycode` and `key_to_keycode`
- **Wrap key events with the appropriate modifier(s)** based on level:
  - Level 1: Shift
  - Level 2/4: AltGr (ISO_Level3_Shift, typically Mod5; falls back to Mod3)
  - Level 3/5: AltGr + Shift
- **Check whether modifier keys are already held** before pressing them, so explicit Shift+key sequences still work correctly
- Add `is_keycode_held` helper to `KeyMap` for the held-key check

Only the x11rb backend is affected. The Wayland, libei, and xdo backends use independent keycode-lookup paths and required no changes.

### XWayland note for reviewers

The loop-order change (commit 2) is specifically needed for XWayland environments. When an X11 application runs under Wayland via XWayland, the keymap includes extended keycodes (above ~200) that map uppercase/shifted keysyms at level 0. These keycodes don't correspond to real keys and XTest events targeting them produce no output in the Wayland compositor. By iterating keycodes in the outer loop, we find the standard keycode (with Shift at level 1) first, which translates correctly through XWayland. On native X11, both orderings produce correct output, but the new order is still preferable as it matches standard keycodes.

Fixes #489, relates to #210 and #37.

## Test plan

- [ ] On an X11 session, call `enigo.text("Hello, World!")` and verify all characters appear correctly
- [ ] Call `enigo.text("ABCDEFGHIJKLMNOPQRSTUVWXYZ")` and verify no characters are dropped
- [ ] Call `enigo.text("!@#$%^&*()")` and verify all shifted symbols appear
- [ ] Call `enigo.key(Key::Unicode('A'), Direction::Click)` and verify a capital A is produced
- [ ] Verify that holding Shift explicitly and then pressing a key still works (no double-Shift)
- [ ] Verify lowercase text like `enigo.text("hello")` still works (level 0, no modifier wrapping)
- [ ] On XWayland, verify `enigo.text("Hello, World!")` produces correct output (exercises the loop-order fix)
- [ ] On a system with an international layout (e.g. Portuguese), verify AltGr characters work: `enigo.text("@")`, `enigo.text("{}")`, etc.
- [ ] On a Wayland session, verify `enigo.text(...)` still works (no regressions from unrelated backends)