### PR TITLE
Restore token fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,18 +98,28 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Check clippy lints
-        run: cargo clippy --no-default-features --features ${{ matrix.features }} -- -D clippy::pedantic
+        run: |
+          cargo clippy --no-default-features --features ${{ matrix.features }} -- -D clippy::pedantic
+          cargo clippy --no-default-features --features ${{ matrix.features }},platform_specific -- -D clippy::pedantic
       - name: Check clippy lints for the examples
-        run: cargo clippy --no-default-features --features ${{ matrix.features }} --examples -- -D clippy::pedantic
+        run: |
+          cargo clippy --no-default-features --features ${{ matrix.features }} --examples -- -D clippy::pedantic
+          cargo clippy --no-default-features --features ${{ matrix.features }},platform_specific --examples -- -D clippy::pedantic
 
       - name: Build the code
-        run: cargo build --no-default-features --features ${{ matrix.features }}
+        run: |
+          cargo build --no-default-features --features ${{ matrix.features }}
+          cargo build --no-default-features --features ${{ matrix.features }},platform_specific
 
       - name: Build the docs
-        run: cargo doc --no-deps --no-default-features --features ${{ matrix.features }}
+        run: |
+          cargo doc --no-deps --no-default-features --features ${{ matrix.features }}
+          cargo doc --no-deps --no-default-features --features ${{ matrix.features }},platform_specific
 
       - name: Build the examples
-        run: cargo build --examples --no-default-features --features ${{ matrix.features }}
+        run: |
+          cargo build --examples --no-default-features --features ${{ matrix.features }}
+          cargo build --examples --no-default-features --features ${{ matrix.features }},platform_specific
 
       - name: Build the examples in release mode
         run: cargo build --release --examples --no-default-features --features ${{ matrix.features }}

--- a/examples/keyboard.rs
+++ b/examples/keyboard.rs
@@ -1,14 +1,24 @@
 use enigo::{
     Direction::{Click, Press, Release},
-    Enigo, Key, Keyboard, Settings,
+    Enigo, Key, Keyboard,
 };
 use std::thread;
 use std::time::Duration;
-
 fn main() {
     env_logger::try_init().ok();
+
+    let token_path = "/tmp/restore_token.txt";
+
+    // Load saved token to only see the permissions dialog once
+    let saved_token = std::fs::read_to_string(token_path).ok();
+
+    let settings = enigo::Settings {
+        restore_token: saved_token,
+        ..Default::default()
+    };
+
     thread::sleep(Duration::from_secs(2));
-    let mut enigo = Enigo::new(&Settings::default()).unwrap();
+    let mut enigo = Enigo::new(&settings).unwrap();
 
     // write text
     enigo
@@ -19,4 +29,9 @@ fn main() {
     enigo.key(Key::Control, Press).unwrap();
     enigo.key(Key::Unicode('a'), Click).unwrap();
     enigo.key(Key::Control, Release).unwrap();
+
+    // Save the new token (tokens rotate on each session)
+    if let Some(token) = enigo.restore_token() {
+        std::fs::write(token_path, token).unwrap();
+    }
 }

--- a/examples/keyboard.rs
+++ b/examples/keyboard.rs
@@ -10,7 +10,14 @@ fn main() {
     let token_path = "/tmp/restore_token.txt";
 
     // Load saved token to only see the permissions dialog once
-    let saved_token = std::fs::read_to_string(token_path).ok();
+    let saved_token = if cfg!(all(
+        feature = "platform_specific",
+        any(feature = "libei", feature = "xdg_desktop")
+    )) {
+        std::fs::read_to_string(token_path).ok()
+    } else {
+        None
+    };
 
     let settings = enigo::Settings {
         restore_token: saved_token,
@@ -31,6 +38,10 @@ fn main() {
     enigo.key(Key::Control, Release).unwrap();
 
     // Save the new token (tokens rotate on each session)
+    #[cfg(all(
+        feature = "platform_specific",
+        any(feature = "libei", feature = "xdg_desktop")
+    ))]
     if let Some(token) = enigo.restore_token() {
         std::fs::write(token_path, token).unwrap();
     }

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -48,7 +48,7 @@ pub enum Token {
     #[cfg_attr(feature = "serde", serde(alias = "s"))]
     Scroll(i32, #[cfg_attr(feature = "serde", serde(default))] Axis),
     /// Call the [`Mouse::smooth_scroll`] fn.
-    /// Only available on macOS with platform_specific feature.
+    /// Only available on macOS with the `platform_specific` feature.
     #[cfg(all(feature = "platform_specific", target_os = "macos"))]
     #[cfg_attr(feature = "serde", serde(alias = "SS"))]
     #[cfg_attr(feature = "serde", serde(alias = "ss"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,7 @@ pub trait Mouse {
     ///
     /// # Arguments
     /// * `length` - The number of pixels to scroll. Positive values scroll
-    /// down/right, negative values scroll up/left.
+    ///   down/right, negative values scroll up/left.
     /// * `axis` - The axis to scroll along (Horizontal or Vertical)
     ///
     /// # Errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,8 +489,9 @@ pub struct Settings {
     /// A restore token from a previous XDG `RemoteDesktop` portal session.
     /// When provided, the portal will attempt to restore the previous session
     /// without showing a permission dialog to the user. After connecting, call
-    /// `restore_token()` to get the new token (tokens rotate) and save it for
-    /// next time. Only used by the libei and `xdg_desktop` backends on Linux.
+    /// `Enigo::restore_token()` (requires the `platform_specific` feature) to
+    /// get the new token (tokens rotate) and save it for next time. Only used
+    /// by the libei and `xdg_desktop` backends on Linux.
     pub restore_token: Option<String>,
 }
 

--- a/src/linux/libei.rs
+++ b/src/linux/libei.rs
@@ -78,6 +78,7 @@ pub struct Con {
     last_serial: u32,
     context: ei::Context,
     connection: Connection,
+    #[cfg(feature = "platform_specific")]
     restore_token: Option<String>,
 }
 
@@ -211,6 +212,8 @@ impl Con {
 
         let (context, restore_token) =
             Self::custom_block_on(Self::open_connection(restore_token))??;
+        #[cfg(not(feature = "platform_specific"))]
+        let _ = restore_token;
 
         let HandshakeResp {
             connection,
@@ -245,6 +248,7 @@ impl Con {
             last_serial: serial,
             context,
             connection,
+            #[cfg(feature = "platform_specific")]
             restore_token,
         };
 
@@ -300,6 +304,7 @@ impl Con {
     /// Callers should save this token and pass it via `Settings::restore_token`
     /// on the next connection to skip the permission dialog.
     #[must_use]
+    #[cfg(feature = "platform_specific")]
     pub fn restore_token(&self) -> Option<String> {
         self.restore_token.clone()
     }

--- a/src/linux/libei.rs
+++ b/src/linux/libei.rs
@@ -126,7 +126,7 @@ impl Con {
 
         let mut options = SelectDevicesOptions::default()
             .set_devices(DeviceType::Keyboard | DeviceType::Pointer)
-            .set_persist_mode(ashpd::desktop::PersistMode::Application);
+            .set_persist_mode(ashpd::desktop::PersistMode::ExplicitlyRevoked);
         if let Some(restore_token) = restore_token {
             options = options.set_restore_token(restore_token);
         }

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -206,9 +206,10 @@ impl Enigo {
         self.held.clone()
     }
 
-    /// Returns the restore token from the portal session, if available.
-    /// Save this token and pass it via `Settings::restore_token` on the next
-    /// connection to avoid the permission dialog.
+    /// Returns the restore token from the portal session when using libei or
+    /// xdg_desktop, if available. Save this token and pass it via
+    /// `Settings::restore_token` on the next connection to avoid the
+    /// permission dialog.
     #[must_use]
     pub fn restore_token(&self) -> Option<String> {
         #[cfg(any(

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -206,8 +206,8 @@ impl Enigo {
         self.held.clone()
     }
 
-    /// Returns the restore token from the portal session when using libei or
-    /// xdg_desktop, if available. Save this token and pass it via
+    /// Returns the restore token from the portal session when using `libei` or
+    /// `xdg_desktop`, if available. Save this token and pass it via
     /// `Settings::restore_token` on the next connection to avoid the
     /// permission dialog.
     #[must_use]

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -211,11 +211,10 @@ impl Enigo {
     /// `Settings::restore_token` on the next connection to avoid the
     /// permission dialog.
     #[must_use]
+    #[cfg(feature = "platform_specific")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "platform_specific")))]
     pub fn restore_token(&self) -> Option<String> {
-        #[cfg(any(
-            all(feature = "xdg_desktop", feature = "tokio"),
-            all(feature = "xdg_desktop", feature = "smol")
-        ))]
+        #[cfg(feature = "xdg_desktop")]
         if let Some(token) = self
             .xdg_desktop
             .as_ref()
@@ -223,10 +222,7 @@ impl Enigo {
         {
             return Some(token);
         }
-        #[cfg(any(
-            all(feature = "libei", feature = "tokio"),
-            all(feature = "libei", feature = "smol")
-        ))]
+        #[cfg(feature = "libei")]
         if let Some(token) = self.libei.as_ref().and_then(libei::Con::restore_token) {
             return Some(token);
         }

--- a/src/linux/xdg_desktop.rs
+++ b/src/linux/xdg_desktop.rs
@@ -44,7 +44,7 @@ impl Con {
 
         let mut options = SelectDevicesOptions::default()
             .set_devices(DeviceType::Keyboard | DeviceType::Pointer)
-            .set_persist_mode(ashpd::desktop::PersistMode::Application);
+            .set_persist_mode(ashpd::desktop::PersistMode::ExplicitlyRevoked);
         if let Some(restore_token) = restore_token {
             options = options.set_restore_token(restore_token);
         }

--- a/src/linux/xdg_desktop.rs
+++ b/src/linux/xdg_desktop.rs
@@ -16,6 +16,7 @@ use crate::{
 pub struct Con {
     session: Session<RemoteDesktop>,
     remote_desktop: RemoteDesktop,
+    #[cfg(feature = "platform_specific")]
     restore_token: Option<String>,
 }
 
@@ -101,9 +102,12 @@ impl Con {
                 error! {"{e}"};
                 NewConError::EstablishCon("failed to create tokio runtime")
             })??;
+        #[cfg(not(feature = "platform_specific"))]
+        let _ = restore_token;
         Ok(Self {
             session,
             remote_desktop,
+            #[cfg(feature = "platform_specific")]
             restore_token,
         })
     }
@@ -112,6 +116,7 @@ impl Con {
     /// Callers should save this token and pass it via `Settings::restore_token`
     /// on the next connection to skip the permission dialog.
     #[must_use]
+    #[cfg(feature = "platform_specific")]
     pub fn restore_token(&self) -> Option<String> {
         self.restore_token.clone()
     }


### PR DESCRIPTION
Gnome and KDE are innocent! They didn't do anything wrong. We didn't ask them to keep the token valid until it is explicitly revoked.