### PR TITLE
win: use a thread DPI context for coordinates and remove set_dpi_awareness

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - linux: wayland: Use `axis_discrete` with a wheel axis source for `scroll()` instead of continuous `axis`
 - all: `Mouse::smooth_scroll` is no longer gated behind the `platform_specific` feature (supported on macOS, Windows, and Linux via xdg_desktop/Wayland/libei; X11 returns an error)
 - all: MSRV is 1.87
+- win: `main_display()` and `location()` temporarily use a per-monitor DPI awareness thread context so coordinates stay correct without changing the process DPI mode
 
 ## Added
 - win: added smooth scrolling via high-resolution `MOUSEEVENTF_WHEEL` / `MOUSEEVENTF_HWHEEL` deltas (`120` = one notch; effect depends on whether the target app handles sub-120 deltas)
@@ -18,12 +19,14 @@
 - linux: added new protocol to simulate input. It uses the xdg_desktop portal and should work in flatpaks. Try it out with the `xdg_desktop` feature
 
 ## Removed
+- win: Removed `set_dpi_awareness()`. Enigo now handles DPI awareness internally where needed
 - win: `EXT` constant was removed, because it was incorrect and obsolete
 - all: Removed the function `delay` and `set_delay` as they no longer serve a purpose
 - all: Removed the field `linux_delay` from `Settings` struct as it no longer serves a purpose
 - linux: libei: Removed `Clone` derive from `Con`
 
 ## Fixed
+- win: Mouse coordinates and display size are no longer wrong when the process is not DPI aware
 - linux: Record pressed keys/keycodes in `held()` again after a successful `key()`/`raw()` (regression from protocol retry refactor)
 - linux: libei: Send `ei_device.ready` on device v3+ after `done` so servers waiting for `EIS_FLAG_DEVICE_READY` resume devices
 - linux: libei: Fix `frame` / `start_emulating` serial vs sequence handling

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ By default, enigo currently works on Windows, macOS and Linux (X11). If you want
 
 There are multiple ways how to simulate input on Linux and not all systems support everything. Enigo can also use wayland protocols and libei to simulate input but there are currently some bugs with it. That is why they are hidden behind feature flags.
 
+On Windows, mouse coordinates and display size use physical pixels. Enigo temporarily switches the calling thread to per-monitor DPI awareness for those queries, so you do not need to change the process DPI awareness mode.
+
 ## Runtime dependencies
 
 Linux users may have to install `libxdo-dev` if they are using the `xdo` feature. For example, on Debian-based distros:

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -11,12 +11,6 @@ use std::time::Duration;
 fn main() {
     env_logger::try_init().ok();
 
-    #[cfg(target_os = "windows")]
-    // This is needed on Windows if you want the application to respect the users scaling settings.
-    // Please look at the documentation of the function to see better ways to achive this and
-    // important gotchas
-    enigo::set_dpi_awareness().unwrap();
-
     let wait_time = Duration::from_secs(2);
     let mut enigo = Enigo::new(&Settings::default()).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,9 +74,6 @@ pub mod agent;
 mod platform;
 pub use platform::Enigo;
 
-#[cfg(target_os = "windows")]
-pub use platform::set_dpi_awareness;
-
 mod keycodes;
 /// Contains the available keycodes
 pub use keycodes::Key;
@@ -379,6 +376,10 @@ pub trait Mouse {
     /// Get the (width, height) of the main display in pixels. This currently
     /// only works on the main display
     ///
+    /// On Windows, the size is reported in physical pixels. Enigo temporarily
+    /// switches the calling thread to per-monitor DPI awareness for the query,
+    /// so the result does not depend on the process DPI awareness mode.
+    ///
     /// # Errors
     /// Have a look at the documentation of [`InputError`] to see under which
     /// conditions an error will be returned.
@@ -386,6 +387,11 @@ pub trait Mouse {
     fn main_display(&self) -> InputResult<(i32, i32)>;
 
     /// Get the location of the mouse in pixels
+    ///
+    /// On Windows, the position is reported in physical pixels. Enigo
+    /// temporarily switches the calling thread to per-monitor DPI awareness for
+    /// the query, so the result does not depend on the process DPI awareness
+    /// mode.
     ///
     /// # Errors
     /// Have a look at the documentation of [`InputError`] to see under which

--- a/src/win/mod.rs
+++ b/src/win/mod.rs
@@ -1,2 +1,2 @@
 mod win_impl;
-pub use win_impl::{Enigo, set_dpi_awareness};
+pub use win_impl::Enigo;

--- a/src/win/win_impl.rs
+++ b/src/win/win_impl.rs
@@ -15,6 +15,9 @@ use windows::Win32::UI::{
     WindowsAndMessaging::{GetForegroundWindow, GetWindowThreadProcessId},
 };
 
+use windows::Win32::UI::HiDpi::{
+    DPI_AWARENESS_CONTEXT, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE, SetThreadDpiAwarenessContext,
+};
 use windows::Win32::UI::WindowsAndMessaging::{
     GetCursorPos, GetSystemMetrics, SM_CXSCREEN, SM_CYSCREEN, WHEEL_DELTA,
 };
@@ -25,6 +28,37 @@ use crate::{
 };
 
 type ScanCode = u16;
+
+/// Temporarily switches the calling thread to per-monitor DPI awareness so that
+/// screen metrics and cursor coordinates are not virtualized by Windows.
+///
+/// The previous DPI awareness context is restored when the guard is dropped, so
+/// the rest of the application keeps its own DPI mode.
+struct ThreadDpiAwarenessGuard {
+    previous: Option<DPI_AWARENESS_CONTEXT>,
+}
+
+impl ThreadDpiAwarenessGuard {
+    fn per_monitor() -> Self {
+        // NULL means the context was invalid and the thread was not updated.
+        // See https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setthreaddpiawarenesscontext
+        let previous =
+            unsafe { SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE) };
+        Self {
+            previous: (!previous.0.is_null()).then_some(previous),
+        }
+    }
+}
+
+impl Drop for ThreadDpiAwarenessGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.take() {
+            unsafe {
+                SetThreadDpiAwarenessContext(previous);
+            }
+        }
+    }
+}
 
 /// The main struct for handling the event emitting
 pub struct Enigo {
@@ -238,8 +272,14 @@ impl Mouse for Enigo {
         self.scroll_wheel(length, axis)
     }
 
+    /// Returns the main display size in physical pixels.
+    ///
+    /// Uses a temporary per-monitor DPI awareness thread context so the values
+    /// are not virtualized when the process itself is not DPI aware.
     fn main_display(&self) -> InputResult<(i32, i32)> {
         debug!("\x1b[93mmain_display()\x1b[0m");
+        // GetSystemMetrics returns virtualized values unless the thread is DPI aware
+        let _dpi_guard = ThreadDpiAwarenessGuard::per_monitor();
         let w = unsafe { GetSystemMetrics(SM_CXSCREEN) };
         let h = unsafe { GetSystemMetrics(SM_CYSCREEN) };
         if w == 0 || h == 0 {
@@ -253,8 +293,14 @@ impl Mouse for Enigo {
         }
     }
 
+    /// Returns the cursor location in physical pixels.
+    ///
+    /// Uses a temporary per-monitor DPI awareness thread context so the values
+    /// are not virtualized when the process itself is not DPI aware.
     fn location(&self) -> InputResult<(i32, i32)> {
         debug!("\x1b[93mlocation()\x1b[0m");
+        // GetCursorPos returns virtualized values unless the thread is DPI aware
+        let _dpi_guard = ThreadDpiAwarenessGuard::per_monitor();
         let mut point = POINT { x: 0, y: 0 };
         if unsafe { GetCursorPos(&raw mut point) }.is_ok() {
             Ok((point.x, point.y))
@@ -568,30 +614,6 @@ impl Enigo {
             _ => false,
         }
     }
-}
-
-/// Sets the current process to a specified dots per inch (dpi) awareness
-/// context [see official documentation](https://learn.microsoft.com/en-us/windows/win32/api/shellscalingapi/nf-shellscalingapi-setprocessdpiawareness)
-/// If you want your applications to respect the users scaling, you need to set
-/// this. Otherwise the mouse coordinates and screen dimensions will be off.
-///
-/// It is recommended that you set the process-default DPI awareness via
-/// application manifest, not an API call. See [Setting the default DPI awareness for a process](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setprocessdpiawarenesscontext) for more information. Setting the process-default DPI
-/// awareness via API call can lead to unexpected application behavior.
-/// It also needs to be set before any APIs are used that depend on the DPI and
-/// before a UI is created.
-/// Enigo is a library and should not set this, because
-/// it will lead to unexpected scaling of the application. Only use it for
-/// examples or if you know about the consequences
-///
-/// # Errors
-/// An error is thrown if the default API awareness mode for the process has
-/// already been set (via a previous API call or within the application
-/// manifest)
-pub fn set_dpi_awareness() -> Result<(), ()> {
-    use windows::Win32::UI::HiDpi::{PROCESS_PER_MONITOR_DPI_AWARE, SetProcessDpiAwareness};
-
-    unsafe { SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE) }.map_err(|_| ())
 }
 
 impl Drop for Enigo {


### PR DESCRIPTION
Query display size and cursor position under a temporary per-monitor DPI awareness context so physical pixels stay correct without changing the process-wide DPI mode.