### PR TITLE
linux: wayland: fix main display detection

### DIFF
--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -711,12 +711,14 @@ impl Dispatch<wl_output::WlOutput, ()> for WaylandState {
                 refresh: _,
             } => {
                 debug!("WlOutput received event:\n{event:?}");
-                if flags == WEnum::Value(Mode::Current) {
-                    if let Some((_, output_data)) =
-                        state.outputs.iter_mut().find(|(o, _)| o == output)
-                    {
-                        output_data.width = width;
-                        output_data.height = height;
+                if let WEnum::Value(value_flags) = flags {
+                    if value_flags.contains(Mode::Current) {
+                        if let Some((_, output_data)) =
+                            state.outputs.iter_mut().find(|(o, _)| o == output)
+                        {
+                            output_data.width = width;
+                            output_data.height = height;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Changed `Mode::Current` bitflags check from equality to membership.
This ensures displays with the bitflag set `WEnum::Value(Mode::Current | Mode::Preferred)` are not skipped.

Prior to this change, `main_display().size()` on a default `Enigo` object, returned `Ok((0, 0))` on my setup (Niri compositor). This also broke `move_mouse` with absolute coordinates as it relies on the detected display size.