### PR TITLE
linux: x11rb: Refresh keymap after MappingNotify

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 ## Fixed
 - win: Mouse coordinates and display size are no longer wrong when the process is not DPI aware
 - linux: Record pressed keys/keycodes in `held()` again after a successful `key()`/`raw()` (regression from protocol retry refactor)
+- linux: x11rb: Refresh cached key and modifier mappings after X11 mapping changes
 - linux: libei: Send `ei_device.ready` on device v3+ after `done` so servers waiting for `EIS_FLAG_DEVICE_READY` resume devices
 - linux: libei: Fix `frame` / `start_emulating` serial vs sequence handling
 - linux: libei: Re-send `start_emulating` after pause/resume so events are not silently discarded

--- a/src/linux/keymap.rs
+++ b/src/linux/keymap.rs
@@ -68,6 +68,66 @@ where
         }
     }
 
+    /// Replace the cached server keymap while retaining additional mappings
+    /// that are still present.
+    pub fn refresh(
+        &mut self,
+        unused_keycodes: VecDeque<Keycode>,
+        keysyms_per_keycode: u8,
+        keysyms: Vec<u32>,
+    ) {
+        self.keymap_mapping
+            .additionally_mapped
+            .retain(|&keysym, &mut keycode| {
+                Self::mapping_contains(
+                    self.keymap_mapping.keycode_min,
+                    keysyms_per_keycode,
+                    &keysyms,
+                    keycode,
+                    keysym,
+                )
+            });
+        self.keymap_mapping.keysyms_per_keycode = keysyms_per_keycode;
+        self.keymap_mapping.keysyms = keysyms;
+        self.keymap_mapping.unused_keycodes = unused_keycodes;
+    }
+
+    fn mapping_contains(
+        keycode_min: Keycode,
+        keysyms_per_keycode: u8,
+        keysyms: &[u32],
+        keycode: Keycode,
+        keysym: Keysym,
+    ) -> bool {
+        let keycode_min: usize = keycode_min.try_into().unwrap();
+        let keycode: usize = keycode.try_into().unwrap();
+        let keysyms_per_keycode = keysyms_per_keycode as usize;
+        let start = (keycode - keycode_min) * keysyms_per_keycode;
+        let end = start + keysyms_per_keycode;
+
+        keysyms
+            .get(start..end)
+            .is_some_and(|mapping| mapping.contains(&keysym.raw()))
+    }
+
+    fn update_mapping(&mut self, keycode: Keycode, keysym: Keysym) {
+        let keycode_min: usize = self.keymap_mapping.keycode_min.try_into().unwrap();
+        let keycode: usize = keycode.try_into().unwrap();
+        let keysyms_per_keycode = self.keymap_mapping.keysyms_per_keycode as usize;
+        let start = (keycode - keycode_min) * keysyms_per_keycode;
+        let end = start + keysyms_per_keycode;
+        let Some(mapping) = self.keymap_mapping.keysyms.get_mut(start..end) else {
+            return;
+        };
+
+        mapping.fill(Keysym::NoSymbol.raw());
+        if keysym != Keysym::NoSymbol {
+            mapping.iter_mut().take(2).for_each(|sym| {
+                *sym = keysym.raw();
+            });
+        }
+    }
+
     fn keysym_to_keycode(&self, keysym: Keysym) -> Option<Keycode> {
         let keycode_min: usize = self.keymap_mapping.keycode_min.try_into().unwrap();
         let keycode_max: usize = self.keymap_mapping.keycode_max.try_into().unwrap();
@@ -139,6 +199,7 @@ where
                 self.keymap_mapping
                     .additionally_mapped
                     .insert(keysym, unused_keycode);
+                self.update_mapping(unused_keycode, keysym);
                 debug!("mapped keycode {unused_keycode} to keysym {keysym:?}");
                 Ok(unused_keycode)
             }
@@ -163,6 +224,7 @@ where
         self.keymap_state.needs_regeneration = true;
         self.keymap_mapping.unused_keycodes.push_back(keycode);
         self.keymap_mapping.additionally_mapped.remove(&keysym);
+        self.update_mapping(keycode, Keysym::NoSymbol);
         debug!("unmapped keysym {keysym:?}");
         Ok(())
     }
@@ -220,3 +282,93 @@ pub trait Bind<Keycode> {
 }
 
 impl<Keycode> Bind<Keycode> for () {}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct Binder {
+        mappings: RefCell<Vec<(u8, Keysym)>>,
+    }
+
+    impl Bind<u8> for Binder {
+        fn bind_key(&self, keycode: u8, keysym: Keysym) -> Result<(), ()> {
+            self.mappings.borrow_mut().push((keycode, keysym));
+            Ok(())
+        }
+    }
+
+    fn keymap() -> KeyMap<u8> {
+        KeyMap::new(
+            8,
+            9,
+            VecDeque::from([9]),
+            2,
+            vec![Keysym::from(Key::Unicode('a')).raw(), 0, 0, 0],
+        )
+    }
+
+    #[test]
+    fn updates_cached_mapping_when_mapping_and_unmapping() {
+        let binder = Binder::default();
+        let mut keymap = keymap();
+        let keysym = Keysym::from(Key::Unicode('€'));
+
+        let keycode = keymap.map(&binder, keysym).unwrap();
+        assert_eq!(keymap.keysym_to_keycode(keysym), Some(keycode));
+
+        keymap.unmap(&binder, keysym, keycode).unwrap();
+        assert_eq!(keymap.keysym_to_keycode(keysym), None);
+    }
+
+    #[test]
+    fn refresh_discards_additional_mappings_removed_by_server() {
+        let binder = Binder::default();
+        let mut keymap = keymap();
+        let keysym = Keysym::from(Key::Unicode('€'));
+        let keycode = keymap.map(&binder, keysym).unwrap();
+
+        keymap.refresh(
+            VecDeque::from([keycode]),
+            2,
+            vec![Keysym::from(Key::Unicode('a')).raw(), 0, 0, 0],
+        );
+
+        assert!(keymap.keymap_mapping.additionally_mapped.is_empty());
+        assert_eq!(
+            keymap.key_to_keycode(&binder, Key::Unicode('€')).unwrap(),
+            keycode
+        );
+    }
+
+    #[test]
+    fn refresh_retains_additional_mappings_still_present_on_server() {
+        let binder = Binder::default();
+        let mut keymap = keymap();
+        let keysym = Keysym::from(Key::Unicode('€'));
+        let keycode = keymap.map(&binder, keysym).unwrap();
+
+        keymap.refresh(
+            VecDeque::new(),
+            2,
+            vec![
+                Keysym::from(Key::Unicode('a')).raw(),
+                0,
+                keysym.raw(),
+                keysym.raw(),
+            ],
+        );
+
+        assert_eq!(
+            keymap.keymap_mapping.additionally_mapped.get(&keysym),
+            Some(&keycode)
+        );
+        assert_eq!(
+            keymap.key_to_keycode(&binder, Key::Unicode('€')).unwrap(),
+            keycode
+        );
+    }
+}

--- a/src/linux/x11rb.rs
+++ b/src/linux/x11rb.rs
@@ -5,9 +5,12 @@ use log::{debug, error, trace, warn};
 use x11rb::{
     connection::Connection,
     protocol::{
+        Event,
         randr::ConnectionExt as _,
         xinput::DeviceUse,
-        xproto::{ConnectionExt as _, GetKeyboardMappingReply, GetModifierMappingReply, Screen},
+        xproto::{
+            ConnectionExt as _, GetKeyboardMappingReply, GetModifierMappingReply, Mapping, Screen,
+        },
         xtest::ConnectionExt as _,
     },
     rust_connection::{ConnectError, ConnectionError, DefaultStream, ReplyError, RustConnection},
@@ -200,6 +203,56 @@ impl Con {
                 |d| Ok(d.device_id),
             )
     }
+
+    fn refresh_keymap_if_changed(&mut self) -> InputResult<()> {
+        let mut keyboard_changed = false;
+        let mut modifiers_changed = false;
+
+        while let Some(event) = self.connection.poll_for_event().map_err(|e| {
+            error!("{e}");
+            InputError::Simulate("error when polling X11 events with x11rb")
+        })? {
+            let Event::MappingNotify(event) = event else {
+                continue;
+            };
+
+            if event.request == Mapping::KEYBOARD {
+                keyboard_changed = true;
+            } else if event.request == Mapping::MODIFIER {
+                modifiers_changed = true;
+            }
+        }
+
+        if keyboard_changed {
+            let setup = self.connection.setup();
+            let min_keycode = setup.min_keycode;
+            let max_keycode = setup.max_keycode;
+            let (keysyms_per_keycode, keysyms) = Self::get_keyboard_mapping(
+                &self.connection,
+                min_keycode,
+                max_keycode,
+            )
+            .map_err(|e| {
+                error!("{e}");
+                InputError::Simulate("error when refreshing the keyboard mapping with x11rb")
+            })?;
+            let unused_keycodes =
+                Self::unused_keycodes(min_keycode, max_keycode, keysyms_per_keycode, &keysyms);
+            self.keymap
+                .refresh(unused_keycodes, keysyms_per_keycode, keysyms);
+            debug!("refreshed the cached X11 keyboard mapping");
+        }
+
+        if modifiers_changed {
+            self.modifiers = Self::find_modifier_keycodes(&self.connection).map_err(|e| {
+                error!("{e}");
+                InputError::Simulate("error when refreshing the modifier mapping with x11rb")
+            })?;
+            debug!("refreshed the cached X11 modifier mapping");
+        }
+
+        Ok(())
+    }
 }
 
 impl Drop for Con {
@@ -235,6 +288,7 @@ impl Keyboard for Con {
     }
 
     fn key(&mut self, key: Key, direction: Direction) -> InputResult<()> {
+        self.refresh_keymap_if_changed()?;
         let keycode = self.keymap.key_to_keycode(&self.connection, key)?;
 
         if log::log_enabled!(log::Level::Debug) {
@@ -470,5 +524,38 @@ impl Mouse for Con {
                 InputError::Simulate("error with the reply of query_pointer with x11rb")
             })?;
         Ok((reply.root_x as i32, reply.root_y as i32))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_refreshes_keymap_after_server_discards_binding() {
+        let mut con = Con::new(None).unwrap();
+        let key = Key::Unicode('🧐');
+        let keysym = Keysym::from(key);
+        let keycode = con.keymap.key_to_keycode(&con.connection, key).unwrap();
+        assert_eq!(
+            con.keymap.keymap_mapping.additionally_mapped.get(&keysym),
+            Some(&keycode)
+        );
+
+        let (external_connection, _) = x11rb::connect(None).unwrap();
+        external_connection
+            .bind_key(keycode, Keysym::NoSymbol)
+            .unwrap();
+
+        con.refresh_keymap_if_changed().unwrap();
+        assert!(
+            !con.keymap
+                .keymap_mapping
+                .additionally_mapped
+                .contains_key(&keysym)
+        );
+
+        let rebound_keycode = con.keymap.key_to_keycode(&con.connection, key).unwrap();
+        assert_eq!(rebound_keycode, keycode);
     }
 }


### PR DESCRIPTION
## Problem

The X11 backend maps keysyms that are not available on the first level of the active layout to spare keycodes and caches those bindings for the lifetime of the connection.

When the X server reloads its keymap—for example after suspend/resume, a layout re-apply, or device hotplug—those additional bindings can be removed. Enigo then continues sending the cached keycodes, so affected characters are silently dropped until the `Enigo` instance is recreated.

This was reproduced in cjpais/Handy#1722, where capitals bound before a keymap reset disappeared from typed output while the transcription remained correct.

## Solution

- Drain pending core `MappingNotify` events before resolving a symbolic key.
- Reload keyboard and modifier mappings when their corresponding maps change.
- Preserve Enigo-created bindings that are still present on the server and discard stale ones that were removed.
- Keep the local keymap snapshot synchronized when Enigo maps or unmaps a spare keycode.

The refresh happens only after the X server reports a mapping change.

## Testing

- Added pure keymap tests covering local map/unmap synchronization and preserving/removing additional bindings during refresh.
- Added an Xvfb regression test that removes an Enigo-created binding through a second X11 connection, processes the resulting `MappingNotify`, and verifies that Enigo rebinds the symbol.
- `cargo fmt --all -- --check`
- `cargo clippy --no-default-features --features x11rb -- -D clippy::pedantic`
