### PR TITLE
windows: mask the shift state out of the virtual key from VkKeyScanExW

### DIFF
--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -1113,3 +1113,53 @@ impl TryFrom<Key> for windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY {
 #[cfg(all(unix, not(target_os = "macos")))]
 #[cfg(any(feature = "wayland", feature = "x11rb", feature = "libei",))]
 pub(crate) type ModifierBitflag = u32;
+
+#[cfg(test)]
+#[cfg(target_os = "windows")]
+mod windows_virtual_key_tests {
+    use super::Key;
+    use windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY;
+
+    /// `VkKeyScanExW` packs the shift state into the high-order byte. Only the
+    /// low-order byte is the virtual key, and a value carrying the shift state
+    /// names no key at all: `MapVirtualKeyExW` returns 0 for it, and the
+    /// character is then silently not typed.
+    #[test]
+    fn a_character_needing_shift_maps_to_a_real_virtual_key() {
+        // Every one of these has a non-zero shift state on a US layout, which
+        // is exactly the case that used to be dropped.
+        for (character, expected) in [
+            ('A', 0x41_u16),
+            ('Z', 0x5a),
+            ('B', 0x42),
+        ] {
+            let vk = VIRTUAL_KEY::try_from(Key::Unicode(character))
+                .expect("a character on the active layout maps to a virtual key");
+            assert_eq!(
+                vk.0, expected,
+                "{character:?} produced {:#06x}, which is not a virtual key",
+                vk.0
+            );
+            assert_eq!(vk.0 & 0xff00, 0, "{character:?} kept its shift state");
+        }
+    }
+
+    /// The unshifted forms were never broken, because their shift state is
+    /// zero and so survived being left in. They must keep working.
+    #[test]
+    fn a_character_needing_no_modifier_is_unchanged() {
+        for (character, expected) in [('a', 0x41_u16), ('z', 0x5a), ('1', 0x31)] {
+            let vk = VIRTUAL_KEY::try_from(Key::Unicode(character)).expect("a virtual key");
+            assert_eq!(vk.0, expected);
+        }
+    }
+
+    /// A shifted character and its unshifted partner are the same physical
+    /// key; the modifier is the caller's business, not the mapping's.
+    #[test]
+    fn the_two_cases_of_a_letter_are_one_key() {
+        let upper = VIRTUAL_KEY::try_from(Key::Unicode('A')).unwrap();
+        let lower = VIRTUAL_KEY::try_from(Key::Unicode('a')).unwrap();
+        assert_eq!(upper.0, lower.0);
+    }
+}

--- a/src/keycodes.rs
+++ b/src/keycodes.rs
@@ -1086,7 +1086,15 @@ impl TryFrom<Key> for windows::Win32::UI::Input::KeyboardAndMouse::VIRTUAL_KEY {
                 if vk < 0 {
                     return Err("Character can't be mapped to virtual key");
                 }
-                VIRTUAL_KEY(vk as u16)
+                // Only the low-order byte is the virtual key, as the comment
+                // above says. Keeping the high-order shift state in the value
+                // produces a virtual key that does not exist: 'A' is 0x0141
+                // rather than 0x41. `MapVirtualKeyExW` then finds no mapping
+                // and returns 0, and `SendInput` is handed scan code 0, so the
+                // character is silently not typed at all. This affects every
+                // character that needs a modifier on the active layout — the
+                // whole of A-Z, and !, @, # and friends.
+                VIRTUAL_KEY(vk as u16 & 0xFF)
             }
             Key::Other(v) => {
                 let Ok(v) = u16::try_from(v) else {


### PR DESCRIPTION
On Windows, `key(Key::Unicode(c), ..)` silently types nothing for any character that needs a modifier on the active layout. `a` works, `A` does not. So do `!`, `@`, `#` and the rest of the shifted symbols.

## Cause

`VkKeyScanExW` returns the virtual key in the low-order byte and the shift state in the high-order byte — as the comment directly above the call in `keycodes.rs` already says. The return value is then used whole:

```rust
VIRTUAL_KEY(vk as u16)
```

For `A` that is `0x0141` rather than `0x41`, because the shift state (1) is still sitting in the high byte. `0x0141` is not a virtual key.

## Why it is silent

`queue_key` calls `translate_key(0x0141, MAPVK_VK_TO_VSC_EX)`. `MapVirtualKeyExW` finds no mapping and returns 0, which `translate_key` only warns about before returning `Ok(0)`. `queue_key` then sets `KEYEVENTF_SCANCODE` for `Key::Unicode` and hands `SendInput` a scan code of 0. Nothing is typed and nothing is returned as an error.

The lower-case forms survive by accident: their shift state is 0, so leaving it in the value is harmless.

## Fix

Mask to the low-order byte. The result is the base key, which the caller combines with whatever modifiers it is already holding — the shift state is deliberately not applied here, since `Keyboard::key` is a press/release of one key and the caller owns modifier state.

## Tests

Three tests in `keycodes.rs`, Windows-only. Two of them fail without the change (`'A' produced 0x0141, which is not a virtual key`) and pass with it; the third pins down that the unshifted characters keep working.

Found in a VNC server, where a remote client could type `abc` but not `ABC`: every capital letter and shifted symbol was dropped on the floor.