### PR TITLE
fix(linux): skip the remote desktop portal outside wayland sessions

### DIFF
--- a/src/linux/xdg_desktop.rs
+++ b/src/linux/xdg_desktop.rs
@@ -22,13 +22,33 @@ pub struct Con {
 
 unsafe impl Send for Con {}
 
+/// Whether the current session is Wayland, which is the only place the
+/// `RemoteDesktop` portal is served.
+fn is_wayland_session() -> bool {
+    if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+        return true;
+    }
+
+    std::env::var("XDG_SESSION_TYPE").is_ok_and(|t| t.eq_ignore_ascii_case("wayland"))
+}
+
 impl Con {
     async fn open_connection(
         restore_token: Option<&str>,
     ) -> Result<(Session<RemoteDesktop>, RemoteDesktop, Option<String>), NewConError> {
         trace!("open_connection");
 
-        // Fallback: use portal
+        // Compositors reject RemoteDesktop outright under X11, and some of them
+        // (KWin) raise a modal error dialog for every attempt, which also steals
+        // focus from whatever the caller was about to type into. Bail out before
+        // asking so the x11 backend is reached silently.
+        if !is_wayland_session() {
+            debug!("not a wayland session, skipping the remote desktop portal");
+            return Err(NewConError::EstablishCon(
+                "the remote desktop portal is only available in wayland sessions",
+            ));
+        }
+
         let remote_desktop = RemoteDesktop::new().await.map_err(|e| {
             error! {"{e}"};
             NewConError::EstablishCon("failed to create RemoteDesktop")


### PR DESCRIPTION
`open_connection` requests a `RemoteDesktop` session before checking what kind of session is running. X11 compositors reject it, so the connection falls through to the x11 backend and input still works, but KWin raises a modal dialog for **every** attempt:

> The application X tried to start a remote desktop session but remote desktop is not available in X11 sessions. Please switch to a Wayland session and try again.

The dialog also takes focus. For anything that simulates a keystroke right after connecting (a clipboard manager pasting into the previously focused window, in my case) the keystroke goes to the dialog instead of the intended window, so the operation silently does the wrong thing.

Trace on an X11/KDE session before the change:

```
DEBUG enigo::platform::xdg_desktop] using xdg desktop
ERROR enigo::platform::xdg_desktop] Portal request didn't succeed with no information
WARN  enigo::platform] no connection could be established: (failed to create remote desktop session)
DEBUG enigo::platform] x11 connection established
```

After:

```
DEBUG enigo::platform::xdg_desktop] not a wayland session, skipping the remote desktop portal
DEBUG enigo::platform] x11 connection established
```

No dialog, and the subsequent paste lands in the right window. Checks `WAYLAND_DISPLAY` then `XDG_SESSION_TYPE`, matching how the rest of the ecosystem detects this. Wayland behaviour is unchanged.