### PR TITLE
linux: wayland: fix protocol compliance and lifecycle bugs

### DIFF
--- a/src/linux/keymap2/mod.rs
+++ b/src/linux/keymap2/mod.rs
@@ -40,6 +40,13 @@ impl Keymap2 {
         debug!("creating new xkb:Keymap");
         debug!("new(format: {format}, size: {size}, ...)");
 
+        // Bound keymap parse cost / DoS from a buggy or malicious compositor.
+        const MAX_KEYMAP_SIZE: u32 = 4 * 1024 * 1024; // 4 MiB
+        if size == 0 || size > MAX_KEYMAP_SIZE {
+            error!("keymap size {size} is outside 1..={MAX_KEYMAP_SIZE}; resetting the keymap");
+            return Err(());
+        }
+
         let mut keymap_file = File::from(fd);
 
         // Check if the file size is correct

--- a/src/linux/keymap2/mod.rs
+++ b/src/linux/keymap2/mod.rs
@@ -37,11 +37,12 @@ impl Keymap2 {
     ) -> Result<Self, ()> {
         use std::io::{Read, Seek, SeekFrom};
 
+        // Bound keymap parse cost / DoS from a buggy or malicious compositor.
+        const MAX_KEYMAP_SIZE: u32 = 4 * 1024 * 1024; // 4 MiB
+
         debug!("creating new xkb:Keymap");
         debug!("new(format: {format}, size: {size}, ...)");
 
-        // Bound keymap parse cost / DoS from a buggy or malicious compositor.
-        const MAX_KEYMAP_SIZE: u32 = 4 * 1024 * 1024; // 4 MiB
         if size == 0 || size > MAX_KEYMAP_SIZE {
             error!("keymap size {size} is outside 1..={MAX_KEYMAP_SIZE}; resetting the keymap");
             return Err(());

--- a/src/linux/keymap2/mod.rs
+++ b/src/linux/keymap2/mod.rs
@@ -221,7 +221,9 @@ impl Keymap2 {
         let mut keymap_file = tempfile::tempfile().map_err(|e| {
             error!("could not create temporary file. Error: {e}");
         })?;
-        write!(keymap_file, "{}", self.parsed_keymap).map_err(|e| {
+        // Compositors (e.g. wlroots) mmap `size` bytes and pass the mapping to
+        // xkb_keymap_new_from_string(), which requires a NUL within that range.
+        write!(keymap_file, "{}\0", self.parsed_keymap).map_err(|e| {
             error!("could not write to temporary file. Error: {e}");
         })?;
         let metadata = keymap_file.metadata().map_err(|e| {

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -14,7 +14,7 @@ use wayland_client::{
         wl_keyboard::{self, WlKeyboard},
         wl_output::{self, Mode, WlOutput},
         wl_pointer::{self, WlPointer},
-        wl_registry,
+        wl_registry::{self, WlRegistry},
         wl_seat::{self, Capability},
     },
 };
@@ -68,14 +68,12 @@ impl Con {
             ));
         }
 
-        let mut state = WaylandState::default();
-
         let mut event_queue = connection.new_event_queue();
         let qh = event_queue.handle();
 
-        // Start registry
+        // Keep the registry alive so Global / GlobalRemove keep being delivered.
         let display = connection.display();
-        let _ = display.get_registry(&qh, ()); // TODO: Check if we can drop the registry here
+        let mut state = WaylandState::new(display.get_registry(&qh, ()));
 
         // Receive the list of available globals
         event_queue
@@ -299,9 +297,10 @@ impl Drop for Con {
     }
 }
 
-#[derive(Default)]
 /// Stores the manager for the various protocols
 struct WaylandState {
+    // Kept for the connection lifetime so registry events keep arriving.
+    _registry: WlRegistry,
     // interface name, global id, version
     globals: Vec<(String, u32, u32)>,
     // registry global name, output, info
@@ -321,6 +320,29 @@ struct WaylandState {
     seat_keyboard: Option<WlKeyboard>,
     seat_keymap: Option<Keymap2>,
     seat_pointer: Option<WlPointer>,
+}
+
+impl WaylandState {
+    fn new(registry: WlRegistry) -> Self {
+        Self {
+            _registry: registry,
+            globals: Vec::new(),
+            outputs: Vec::new(),
+            keyboard_manager: None,
+            virtual_keyboard: None,
+            im_manager: None,
+            input_method: None,
+            im_serial: Wrapping(0),
+            im_pending_active: false,
+            im_active: false,
+            pointer_manager: None,
+            virtual_pointer: None,
+            seat: None,
+            seat_keyboard: None,
+            seat_keymap: None,
+            seat_pointer: None,
+        }
+    }
 }
 
 impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -307,6 +307,10 @@ struct WaylandState {
     im_manager: Option<zwp_input_method_manager_v2::ZwpInputMethodManagerV2>,
     input_method: Option<zwp_input_method_v2::ZwpInputMethodV2>,
     im_serial: Wrapping<u32>,
+    /// Pending activate/deactivate (applied on `done`).
+    im_pending_active: bool,
+    /// Whether the input method is currently active (after last `done`).
+    im_active: bool,
     pointer_manager: Option<zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1>,
     virtual_pointer: Option<zwlr_virtual_pointer_v1::ZwlrVirtualPointerV1>,
     seat: Option<wl_seat::WlSeat>,
@@ -344,6 +348,8 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                                 let input_method = im_manager.get_input_method(&seat, qh, ());
                                 state.input_method = Some(input_method);
                                 state.im_serial = Wrapping(0u32);
+                                state.im_pending_active = false;
+                                state.im_active = false;
                             }
                         }
                         // We don't know if the seat or the keyboard_manager is created first and we
@@ -391,6 +397,8 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                                 let input_method = im_manager.get_input_method(seat, qh, ());
                                 state.input_method = Some(input_method);
                                 state.im_serial = Wrapping(0u32);
+                                state.im_pending_active = false;
+                                state.im_active = false;
                             }
                         }
                         state.im_manager = Some(im_manager);
@@ -465,6 +473,8 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                         if let Some(im) = state.input_method.take() {
                             im.destroy();
                         }
+                        state.im_pending_active = false;
+                        state.im_active = false;
                         if let Some(vp) = state.virtual_pointer.take() {
                             vp.destroy();
                         }
@@ -481,6 +491,8 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                     "zwp_input_method_manager_v2" => {
                         state.input_method = None;
                         state.im_manager = None;
+                        state.im_pending_active = false;
+                        state.im_active = false;
                     }
                     "zwp_virtual_keyboard_manager_v1" => {
                         state.virtual_keyboard = None;
@@ -549,11 +561,18 @@ impl Dispatch<zwp_input_method_v2::ZwpInputMethodV2, ()> for WaylandState {
         match event {
             zwp_input_method_v2::Event::Done => {
                 debug!("ZwpInputMethodV2 received event:\nzwp_input_method_v2::Event::Done");
+                state.im_active = state.im_pending_active;
                 state.im_serial += Wrapping(1u32);
             }
-            zwp_input_method_v2::Event::Activate
-            | zwp_input_method_v2::Event::Deactivate
-            | zwp_input_method_v2::Event::SurroundingText {
+            zwp_input_method_v2::Event::Activate => {
+                trace!("ZwpInputMethodV2 received event:\nzwp_input_method_v2::Event::Activate");
+                state.im_pending_active = true;
+            }
+            zwp_input_method_v2::Event::Deactivate => {
+                trace!("ZwpInputMethodV2 received event:\nzwp_input_method_v2::Event::Deactivate");
+                state.im_pending_active = false;
+            }
+            zwp_input_method_v2::Event::SurroundingText {
                 text: _,
                 cursor: _,
                 anchor: _,
@@ -574,6 +593,8 @@ impl Dispatch<zwp_input_method_v2::ZwpInputMethodV2, ()> for WaylandState {
                 if let Some(im) = state.input_method.take() {
                     im.destroy();
                 }
+                state.im_pending_active = false;
+                state.im_active = false;
             }
             _ => warn!("ZwpInputMethodV2 received unknown event:\n{event:?}"),
         }
@@ -793,22 +814,55 @@ impl Drop for WaylandState {
 
 impl Keyboard for Con {
     fn fast_text(&mut self, text: &str) -> InputResult<Option<()>> {
-        // Process all previous events so that the serial number is correct
+        // Process all previous events so that the serial number and active
+        // state are correct
         self.event_queue
             .roundtrip(&mut self.state)
             .map_err(|_| InputError::Simulate("The roundtrip on Wayland failed"))?;
 
-        let Some(im) = self.state.input_method.as_mut() else {
+        let Some(im) = self.state.input_method.clone() else {
             return Ok(None);
         };
 
-        is_alive(im)?;
-        trace!("fast text input with imput_method protocol");
+        // Inactive commits are accepted but have no effect; let the caller
+        // fall back to key-by-key entry.
+        if !self.state.im_active {
+            trace!("input_method inactive; skipping fast_text");
+            return Ok(None);
+        }
 
-        im.commit_string(text.to_string());
-        im.commit(self.state.im_serial.0);
+        is_alive(&im)?;
+        trace!("fast text input with input_method protocol");
 
-        self.flush()?;
+        // commit_string is limited to 4000 bytes per the protocol.
+        fn utf8_chunks(text: &str, max_bytes: usize) -> impl Iterator<Item = &str> {
+            std::iter::from_fn({
+                let mut rest = text;
+                move || {
+                    if rest.is_empty() {
+                        return None;
+                    }
+                    let mut end = rest.len().min(max_bytes);
+                    while end > 0 && !rest.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    // max_bytes is well above the max UTF-8 char width (4), so a
+                    // non-empty `rest` always yields a non-empty chunk.
+                    debug_assert!(end > 0);
+                    let (chunk, next) = rest.split_at(end);
+                    rest = next;
+                    Some(chunk)
+                }
+            })
+        }
+
+        let serial = self.state.im_serial.0;
+        for chunk in utf8_chunks(text, 4000) {
+            im.commit_string(chunk.to_string());
+            im.commit(serial);
+            // Flush each chunk so large pastes are not held in one write.
+            self.flush()?;
+        }
 
         Ok(Some(()))
     }

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -334,6 +334,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                 debug!("Global announced: {interface} (name: {name}, version: {version})");
                 match &interface[..] {
                     "wl_seat" => {
+                        let version = bind_version::<wl_seat::WlSeat>(version);
                         let seat = registry.bind::<wl_seat::WlSeat, _, _>(name, version, qh, ());
                         // We don't know if the seat or the im_manager is created first and we need
                         // both to get the input_method
@@ -366,11 +367,15 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                         state.seat = Some(seat);
                     }
                     "wl_output" => {
+                        let version = bind_version::<wl_output::WlOutput>(version);
                         let wl_output =
                             registry.bind::<wl_output::WlOutput, _, _>(name, version, qh, ());
                         state.outputs.push((wl_output, OutputInfo::default()));
                     }
                     "zwp_input_method_manager_v2" => {
+                        let version = bind_version::<
+                            zwp_input_method_manager_v2::ZwpInputMethodManagerV2,
+                        >(version);
                         let im_manager = registry
                             .bind::<zwp_input_method_manager_v2::ZwpInputMethodManagerV2, _, _>(
                             name,
@@ -390,6 +395,9 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                         state.im_manager = Some(im_manager);
                     }
                     "zwp_virtual_keyboard_manager_v1" => {
+                        let version = bind_version::<
+                            zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1,
+                        >(version);
                         let keyboard_manager = registry
                         .bind::<zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1, _, _>(
                         name,
@@ -409,6 +417,9 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                         state.keyboard_manager = Some(keyboard_manager);
                     }
                     "zwlr_virtual_pointer_manager_v1" => {
+                        let version = bind_version::<
+                            zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1,
+                        >(version);
                         let pointer_manager = registry
                         .bind::<zwlr_virtual_pointer_manager_v1::ZwlrVirtualPointerManagerV1, _, _>(
                         name,
@@ -1045,4 +1056,9 @@ fn is_alive<P: wayland_client::Proxy>(proxy: &P) -> InputResult<()> {
     } else {
         Err(InputError::Simulate("wayland proxy is dead"))
     }
+}
+
+/// Bind at most the version supported by our generated protocol bindings.
+fn bind_version<P: wayland_client::Proxy>(advertised: u32) -> u32 {
+    advertised.min(P::interface().version)
 }

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -871,27 +871,6 @@ impl Keyboard for Con {
         trace!("fast text input with input_method protocol");
 
         // commit_string is limited to 4000 bytes per the protocol.
-        fn utf8_chunks(text: &str, max_bytes: usize) -> impl Iterator<Item = &str> {
-            std::iter::from_fn({
-                let mut rest = text;
-                move || {
-                    if rest.is_empty() {
-                        return None;
-                    }
-                    let mut end = rest.len().min(max_bytes);
-                    while end > 0 && !rest.is_char_boundary(end) {
-                        end -= 1;
-                    }
-                    // max_bytes is well above the max UTF-8 char width (4), so a
-                    // non-empty `rest` always yields a non-empty chunk.
-                    debug_assert!(end > 0);
-                    let (chunk, next) = rest.split_at(end);
-                    rest = next;
-                    Some(chunk)
-                }
-            })
-        }
-
         let serial = self.state.im_serial.0;
         for chunk in utf8_chunks(text, 4000) {
             im.commit_string(chunk.to_string());
@@ -1157,6 +1136,28 @@ fn is_alive<P: wayland_client::Proxy>(proxy: &P) -> InputResult<()> {
     } else {
         Err(InputError::Simulate("wayland proxy is dead"))
     }
+}
+
+/// Split `text` into UTF-8 chunks of at most `max_bytes` each.
+fn utf8_chunks(text: &str, max_bytes: usize) -> impl Iterator<Item = &str> {
+    std::iter::from_fn({
+        let mut rest = text;
+        move || {
+            if rest.is_empty() {
+                return None;
+            }
+            let mut end = rest.len().min(max_bytes);
+            while end > 0 && !rest.is_char_boundary(end) {
+                end -= 1;
+            }
+            // max_bytes is well above the max UTF-8 char width (4), so a
+            // non-empty `rest` always yields a non-empty chunk.
+            debug_assert!(end > 0);
+            let (chunk, next) = rest.split_at(end);
+            rest = next;
+            Some(chunk)
+        }
+    })
 }
 
 /// Bind at most the version supported by our generated protocol bindings.

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -300,7 +300,8 @@ impl Drop for Con {
 struct WaylandState {
     // interface name, global id, version
     globals: Vec<(String, u32, u32)>,
-    outputs: Vec<(WlOutput, OutputInfo)>,
+    // registry global name, output, info
+    outputs: Vec<(u32, WlOutput, OutputInfo)>,
     keyboard_manager: Option<zwp_virtual_keyboard_manager_v1::ZwpVirtualKeyboardManagerV1>,
     virtual_keyboard: Option<zwp_virtual_keyboard_v1::ZwpVirtualKeyboardV1>,
     im_manager: Option<zwp_input_method_manager_v2::ZwpInputMethodManagerV2>,
@@ -370,7 +371,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                         let version = bind_version::<wl_output::WlOutput>(version);
                         let wl_output =
                             registry.bind::<wl_output::WlOutput, _, _>(name, version, qh, ());
-                        state.outputs.push((wl_output, OutputInfo::default()));
+                        state.outputs.push((name, wl_output, OutputInfo::default()));
                     }
                     "zwp_input_method_manager_v2" => {
                         let version = bind_version::<
@@ -470,7 +471,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
                     "wl_output" => {
                         state
                             .outputs
-                            .retain(|(output, _)| output.id().protocol_id() != *name);
+                            .retain(|(global_name, _, _)| *global_name != *name);
                     }
                     "zwp_input_method_manager_v2" => {
                         state.input_method = None;
@@ -708,8 +709,8 @@ impl Dispatch<wl_output::WlOutput, ()> for WaylandState {
                     || transform == WEnum::Value(wl_output::Transform::Flipped90)
                     || transform == WEnum::Value(wl_output::Transform::Flipped270)
                 {
-                    if let Some((_, output_data)) =
-                        state.outputs.iter_mut().find(|(o, _)| o == output)
+                    if let Some((_, _, output_data)) =
+                        state.outputs.iter_mut().find(|(_, o, _)| o == output)
                     {
                         output_data.transform = true;
                     }
@@ -724,8 +725,8 @@ impl Dispatch<wl_output::WlOutput, ()> for WaylandState {
                 debug!("WlOutput received event:\n{event:?}");
                 if let WEnum::Value(value_flags) = flags {
                     if value_flags.contains(Mode::Current) {
-                        if let Some((_, output_data)) =
-                            state.outputs.iter_mut().find(|(o, _)| o == output)
+                        if let Some((_, _, output_data)) =
+                            state.outputs.iter_mut().find(|(_, o, _)| o == output)
                         {
                             output_data.width = width;
                             output_data.height = height;
@@ -1033,10 +1034,10 @@ impl Mouse for Con {
         // is the main display. This likely can be wrong
         match self.state.outputs.first() {
             // Switch width and height if the output was transformed
-            Some((_, output_info)) if output_info.transform => {
+            Some((_, _, output_info)) if output_info.transform => {
                 Ok((output_info.height, output_info.width))
             }
-            Some((_, output_info)) => Ok((output_info.width, output_info.height)),
+            Some((_, _, output_info)) => Ok((output_info.width, output_info.height)),
             None => Err(InputError::Simulate("No screens available")),
         }
     }

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -1139,20 +1139,28 @@ fn is_alive<P: wayland_client::Proxy>(proxy: &P) -> InputResult<()> {
 }
 
 /// Split `text` into UTF-8 chunks of at most `max_bytes` each.
+///
+/// Chunks never split a Unicode scalar value. If the next scalar needs more
+/// than `max_bytes` (possible when `max_bytes < 4`), that scalar is still
+/// emitted alone so iteration makes progress. `max_bytes == 0` yields nothing.
 fn utf8_chunks(text: &str, max_bytes: usize) -> impl Iterator<Item = &str> {
     std::iter::from_fn({
         let mut rest = text;
         move || {
-            if rest.is_empty() {
+            if rest.is_empty() || max_bytes == 0 {
                 return None;
             }
             let mut end = rest.len().min(max_bytes);
             while end > 0 && !rest.is_char_boundary(end) {
                 end -= 1;
             }
-            // max_bytes is well above the max UTF-8 char width (4), so a
-            // non-empty `rest` always yields a non-empty chunk.
-            debug_assert!(end > 0);
+            if end == 0 {
+                // Next scalar needs more than max_bytes; emit it alone.
+                end = rest.chars().next().map_or(0, char::len_utf8);
+                if end == 0 {
+                    return None;
+                }
+            }
             let (chunk, next) = rest.split_at(end);
             rest = next;
             Some(chunk)
@@ -1163,4 +1171,79 @@ fn utf8_chunks(text: &str, max_bytes: usize) -> impl Iterator<Item = &str> {
 /// Bind at most the version supported by our generated protocol bindings.
 fn bind_version<P: wayland_client::Proxy>(advertised: u32) -> u32 {
     advertised.min(P::interface().version)
+}
+
+#[cfg(test)]
+mod utf8_chunks_tests {
+    use super::utf8_chunks;
+
+    fn chunks<'a>(text: &'a str, max_bytes: usize) -> Vec<&'a str> {
+        utf8_chunks(text, max_bytes).collect()
+    }
+
+    #[test]
+    fn empty_inputs() {
+        assert!(chunks("", 0).is_empty());
+        assert!(chunks("", 1).is_empty());
+        assert!(chunks("", 4000).is_empty());
+        assert!(chunks("hello", 0).is_empty());
+        assert!(chunks("😀", 0).is_empty());
+    }
+
+    #[test]
+    fn max_bytes_one_ascii() {
+        assert_eq!(chunks("ab", 1), ["a", "b"]);
+        assert_eq!(chunks("xyz", 1), ["x", "y", "z"]);
+    }
+
+    #[test]
+    fn max_bytes_one_or_two_with_multibyte() {
+        // é is U+00E9 → 2 bytes (C3 A9)
+        assert_eq!(chunks("é", 1), ["é"]); // exceeds budget to make progress
+        assert_eq!(chunks("éé", 2), ["é", "é"]);
+        assert_eq!(chunks("aé", 2), ["a", "é"]); // 'a'+start of é doesn't fit → "a", then "é"
+
+        // emoji is 4 bytes
+        assert_eq!(chunks("😀", 1), ["😀"]);
+        assert_eq!(chunks("😀", 2), ["😀"]);
+        assert_eq!(chunks("😀x", 2), ["😀", "x"]);
+    }
+
+    #[test]
+    fn emoji_and_ascii_at_cut_boundary() {
+        // "hi" = 2 bytes, "😀" = 4 → total 6 before '!'
+        assert_eq!(chunks("hi😀!", 5), ["hi", "😀!"]); // remainder "😀!" is exactly 5
+        assert_eq!(chunks("hi😀!", 6), ["hi😀", "!"]);
+        assert_eq!(chunks("hi😀!", 4), ["hi", "😀", "!"]);
+        assert_eq!(chunks("a😀b😀c", 4), ["a", "😀", "b", "😀", "c"]);
+        assert_eq!(chunks("a😀b😀c", 5), ["a😀", "b😀", "c"]);
+    }
+
+    #[test]
+    fn three_byte_and_combining_marks() {
+        // CJK ideographs are 3 bytes each in UTF-8
+        assert_eq!(chunks("日本語", 3), ["日", "本", "語"]);
+        assert_eq!(chunks("日本語", 5), ["日", "本", "語"]); // 5 is mid-second-char
+        assert_eq!(chunks("日本語", 6), ["日本", "語"]);
+
+        // combining acute accent (U+0301) is 2 bytes; stays with previous only
+        // if they fit in the same budget — with max 1 they split
+        let combining = "a\u{0301}"; // á
+        assert_eq!(chunks(combining, 1), ["a", "\u{0301}"]);
+        assert_eq!(chunks(combining, 3), [combining]);
+    }
+
+    #[test]
+    fn unusual_max_bytes() {
+        assert_eq!(chunks("abc", 3), ["abc"]);
+        assert_eq!(chunks("abcdef", 3), ["abc", "def"]);
+        assert_eq!(chunks("hi", 100), ["hi"]);
+        assert_eq!(chunks("x", usize::MAX), ["x"]);
+        // Exactly one byte over a clean ASCII split
+        assert_eq!(chunks("abcd", 3), ["abc", "d"]);
+        // Protocol-sized limit still works for mixed text
+        let text = "hello 😀 日本語!";
+        assert_eq!(chunks(text, 4000).concat(), text);
+        assert_eq!(chunks(text, 4000), [text]);
+    }
 }

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -457,12 +457,17 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandState {
 
                 match &interface[..] {
                     "wl_seat" => {
-                        state.virtual_keyboard = None;
-                        state.keyboard_manager = None;
-                        state.input_method = None;
-                        state.im_manager = None;
-                        state.virtual_pointer = None;
-                        state.pointer_manager = None;
+                        // Seat-created devices go away with the seat; managers are
+                        // separate globals and must stay so they can be reused.
+                        if let Some(vk) = state.virtual_keyboard.take() {
+                            vk.destroy();
+                        }
+                        if let Some(im) = state.input_method.take() {
+                            im.destroy();
+                        }
+                        if let Some(vp) = state.virtual_pointer.take() {
+                            vp.destroy();
+                        }
                         state.seat_keyboard = None;
                         state.seat_keymap = None;
                         state.seat_pointer = None;

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -176,7 +176,11 @@ impl Con {
         is_alive(vk)?;
 
         let time = self.get_time();
-        let keycode = keycode - 8; // Adjust by 8 due to the xkb/xwayland requirements
+        // XKB/X11 keycodes are offset by 8 from the evdev codes the virtual
+        // keyboard protocol expects. Reject values that would underflow.
+        let keycode = keycode.checked_sub(8).ok_or(InputError::InvalidInput(
+            "the keycode must be at least 8 (X11 keycode offset)",
+        ))?;
         let direction_wayland = match direction {
             Direction::Press => 1,
             Direction::Release => 0,

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -1004,9 +1004,11 @@ impl Mouse for Con {
             Axis::Vertical => wl_pointer::Axis::VerticalScroll,
         };
         let value = f64::from(length) * DEGREES_PER_WHEEL_CLICK;
-        trace!("vp.axis_source(Wheel); vp.axis_discrete(time, axis, {value}, {length})");
-        vp.axis_source(wl_pointer::AxisSource::Wheel);
+        // wlroots applies axis_source to pointer->axis (set by axis/axis_discrete).
+        // Send axis data first, then source, then frame.
+        trace!("vp.axis_discrete(time, axis, {value}, {length}); vp.axis_source(Wheel)");
         vp.axis_discrete(time, axis, value, length);
+        vp.axis_source(wl_pointer::AxisSource::Wheel);
         vp.frame();
 
         self.flush()
@@ -1028,9 +1030,10 @@ impl Mouse for Con {
             Axis::Horizontal => wl_pointer::Axis::HorizontalScroll,
             Axis::Vertical => wl_pointer::Axis::VerticalScroll,
         };
-        trace!("vp.axis_source(Continuous); vp.axis(time, axis, {length}.into())");
-        vp.axis_source(wl_pointer::AxisSource::Continuous);
+        // Same ordering constraint as scroll(): axis before axis_source (wlroots).
+        trace!("vp.axis(time, axis, {length}.into()); vp.axis_source(Continuous)");
         vp.axis(time, axis, length.into());
+        vp.axis_source(wl_pointer::AxisSource::Continuous);
         vp.frame();
 
         self.flush()

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -644,16 +644,26 @@ impl Dispatch<wl_seat::WlSeat, ()> for WaylandState {
                     return;
                 };
 
-                // Create a WlKeyboard if the seat has the capability
-                if state.seat_keyboard.is_none() && capabilities.contains(Capability::Keyboard) {
-                    let seat_keyboard = seat.get_keyboard(qh, ());
-                    state.seat_keyboard = Some(seat_keyboard);
+                if capabilities.contains(Capability::Keyboard) {
+                    if state.seat_keyboard.is_none() {
+                        state.seat_keyboard = Some(seat.get_keyboard(qh, ()));
+                    }
+                } else if let Some(keyboard) = state.seat_keyboard.take() {
+                    // Spec: release when the capability is gone.
+                    if keyboard.version() >= wl_keyboard::REQ_RELEASE_SINCE {
+                        keyboard.release();
+                    }
+                    state.seat_keymap = None;
                 }
 
-                // Create a WlPointer if the seat has the capability
-                if state.seat_pointer.is_none() && capabilities.contains(Capability::Pointer) {
-                    let seat_pointer = seat.get_pointer(qh, ());
-                    state.seat_pointer = Some(seat_pointer);
+                if capabilities.contains(Capability::Pointer) {
+                    if state.seat_pointer.is_none() {
+                        state.seat_pointer = Some(seat.get_pointer(qh, ()));
+                    }
+                } else if let Some(pointer) = state.seat_pointer.take() {
+                    if pointer.version() >= wl_pointer::REQ_RELEASE_SINCE {
+                        pointer.release();
+                    }
                 }
             }
             wl_seat::Event::Name { name: _ } => {

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -570,8 +570,10 @@ impl Dispatch<zwp_input_method_v2::ZwpInputMethodV2, ()> for WaylandState {
                 warn!(
                     "It is not possible to enter text anymore! The characters will now be simulated by individual key presses instead"
                 );
-                state.input_method = None;
-                state.im_manager = None;
+                // Object is inert; destroy it. Keep im_manager — it is a separate global.
+                if let Some(im) = state.input_method.take() {
+                    im.destroy();
+                }
             }
             _ => warn!("ZwpInputMethodV2 received unknown event:\n{event:?}"),
         }


### PR DESCRIPTION
## Summary
Fixes several Linux Wayland protocol and lifecycle bugs found in a backend audit: safer global binding/teardown, correct virtual pointer/keyboard and input-method behavior, and tighter keymap/keycode handling.

## Changes
- Clamp registry binds to client-supported versions; keep `WlRegistry` for the connection lifetime
- Match `wl_output` removal by registry name; release seat keyboard/pointer when capabilities are lost
- Keep protocol managers across seat removal; destroy IM on `Unavailable` while keeping the manager
- Send `axis`/`axis_discrete` before `axis_source` (wlroots); NUL-terminate VK keymap FDs
- Skip `fast_text` when IM is inactive; chunk `commit_string` UTF-8 safely
- Cap seat keymap size (4 MiB); reject keycodes below 8 before the evdev offset