### PR TITLE
linux: wayland: Fix modifier handling

### DIFF
--- a/src/linux/keymap2/mod.rs
+++ b/src/linux/keymap2/mod.rs
@@ -252,13 +252,17 @@ impl Keymap2 {
 
     pub fn key_to_keycode(&self, key: Key) -> Option<u16> {
         let keysym = Keysym::from(key);
-        let key_name = format!("{keysym:?}");
+        let key_name = format!("{keysym:?}").to_lowercase();
 
         (self.keymap.min_keycode().raw()..self.keymap.max_keycode().raw())
             .find(|&k| {
                 let keycode = Keycode::new(k);
+                // key_get_one_sym is affected by modifiers, while the `key_name` parameter
+                // always has the same casing. There are more elegant ways to do
+                // this, potentially with xkb Keymap::key_get_syms_by_level, but
+                // this is the simplest fix.
                 let keysym = self.state.key_get_one_sym(keycode);
-                format!("{keysym:?}") == key_name
+                format!("{keysym:?}").to_lowercase() == key_name
             })
             .and_then(|k| u16::try_from(k).ok())
     }

--- a/src/linux/keymap2/mod.rs
+++ b/src/linux/keymap2/mod.rs
@@ -133,7 +133,7 @@ impl Keymap2 {
             keymap,
             mut state,
             parsed_keymap,
-            pressed_keys,
+            pressed_keys: _,
             original_keymap: _, // Never update the original keymap
         } = Self::new_from_fd(self.context.clone(), format, fd, size).map_err(|()| {
             trace!("unable to create new keymap");
@@ -141,7 +141,7 @@ impl Keymap2 {
 
         // The docs say this is a bad idea. update_key and update_mask should not get
         // mixed. I don't know how else to get the same state though
-        for key in pressed_keys {
+        for &key in &self.pressed_keys {
             state.update_key(key, KeyDirection::Down);
         }
 

--- a/src/linux/keymap2/parse_keymap.rs
+++ b/src/linux/keymap2/parse_keymap.rs
@@ -95,7 +95,8 @@ impl ParsedKeymap {
             code: free_keycode_u32,
         });
 
-        let symbols_string = format!("{{\t[ {key_name}, {key_name} ] }}");
+        let upper_key_name = key_name.to_uppercase();
+        let symbols_string = format!("{{\t[ {key_name}, {upper_key_name} ] }}");
         self.symbols.keys.push((free_identifier, symbols_string));
 
         // Update the maximum if it is needed

--- a/src/linux/wayland.rs
+++ b/src/linux/wayland.rs
@@ -916,17 +916,21 @@ impl Keyboard for Con {
     fn raw(&mut self, keycode: u16, direction: Direction) -> InputResult<()> {
         if direction == Direction::Click || direction == Direction::Press {
             // Update keymap state
+            let changed = self
+                .state
+                .seat_keymap
+                .as_mut()
+                .ok_or(InputError::Simulate("no keymap available"))?
+                .update_key(xkb::Keycode::new(keycode.into()), xkb::KeyDirection::Down);
+
+            self.send_key_event(keycode.into(), Direction::Press)?;
+
             if let Some((
                 depressed_mods_new,
                 latched_mods_new,
                 locked_mods_new,
                 effective_layout_new,
-            )) = self
-                .state
-                .seat_keymap
-                .as_mut()
-                .ok_or(InputError::Simulate("no keymap available"))?
-                .update_key(xkb::Keycode::new(keycode.into()), xkb::KeyDirection::Down)
+            )) = changed
             {
                 trace!("it is a modifier");
                 self.send_modifier_event(
@@ -935,23 +939,25 @@ impl Keyboard for Con {
                     locked_mods_new,
                     effective_layout_new,
                 )?;
-            } else {
-                self.send_key_event(keycode.into(), Direction::Press)?;
             }
         }
         if direction == Direction::Click || direction == Direction::Release {
             // Update keymap state
+            let changed = self
+                .state
+                .seat_keymap
+                .as_mut()
+                .ok_or(InputError::Simulate("no keymap available"))?
+                .update_key(xkb::Keycode::new(keycode.into()), xkb::KeyDirection::Up);
+
+            self.send_key_event(keycode.into(), Direction::Release)?;
+
             if let Some((
                 depressed_mods_new,
                 latched_mods_new,
                 locked_mods_new,
                 effective_layout_new,
-            )) = self
-                .state
-                .seat_keymap
-                .as_mut()
-                .ok_or(InputError::Simulate("no keymap available"))?
-                .update_key(xkb::Keycode::new(keycode.into()), xkb::KeyDirection::Up)
+            )) = changed
             {
                 trace!("it is a modifier");
                 self.send_modifier_event(
@@ -960,8 +966,6 @@ impl Keyboard for Con {
                     locked_mods_new,
                     effective_layout_new,
                 )?;
-            } else {
-                self.send_key_event(keycode.into(), Direction::Release)?;
             }
         }
         Ok(())


### PR DESCRIPTION
Applies several fixes to Wayland modifier handling, with particular emphasis on shift handling.

Most notably, modifier key presses (shift, ctrl, etc) now emit a key event as well as a modifier event.